### PR TITLE
Update installation command in README for duh cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ that easily rival or exceed the performance of other RPC frameworks
 
 Install the `duh` cli linter and generator
 ```bash
-go install github.com/duh-cli/duh-cli@latest
+go install github.com/duh-rpc/duh-cli/cmd/duh@latest
 ```
 
 Get a DUH-RPC service up and running in minutes:


### PR DESCRIPTION
Minor fix to the README to install the duh cli tool.