### PR TITLE
Add streaming support

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
+	"github.com/duh-rpc/duh.go/v2/stream"
 	"golang.org/x/net/http2"
 	json "google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -35,7 +36,13 @@ import (
 
 type Client struct {
 	Client *http.Client
+	// MaxFramePayload is the maximum payload size for streaming frames.
+	// 0 uses DefaultMaxFramePayload.
+	MaxFramePayload int
 }
+
+// DefaultMaxFramePayload is the default maximum payload size for streaming frames.
+const DefaultMaxFramePayload = 4 * MegaByte
 
 const (
 	DetailsHttpCode       = "http.code"
@@ -225,5 +232,123 @@ func NewClientError(msg string, err error, details map[string]string) error {
 		httpCode: CodeClientError,
 		details:  details,
 		err:      err,
+	}
+}
+
+// DoStream sends the request and returns a StreamReader that reads structured
+// stream frames from the response body. The caller must call StreamReader.Close
+// when done to release resources.
+func (c *Client) DoStream(ctx context.Context, req *http.Request) (StreamReader, error) {
+	childCtx, cancel := context.WithCancel(ctx)
+	req = req.WithContext(childCtx)
+
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		cancel()
+		return nil, NewClientError("during client.Do(): %w", err, map[string]string{
+			DetailsHttpUrl:    req.URL.String(),
+			DetailsHttpMethod: req.Method,
+		})
+	}
+
+	if resp.StatusCode != CodeOK {
+		cancel()
+		return nil, handleErrorResponse(req, resp)
+	}
+
+	ct := TrimSuffix(resp.Header.Get("Content-Type"), ";,")
+	ct = strings.TrimSpace(strings.ToLower(ct))
+
+	var unmarshalFn func([]byte, proto.Message) error
+	switch ct {
+	case ContentStreamJSON:
+		unmarshalFn = json.Unmarshal
+	case ContentStreamProtoBuf:
+		unmarshalFn = proto.Unmarshal
+	default:
+		cancel()
+		var body bytes.Buffer
+		_, _ = io.Copy(&body, resp.Body)
+		_ = resp.Body.Close()
+		return nil, NewInfraError(req, resp, body.Bytes())
+	}
+
+	maxPayload := c.MaxFramePayload
+	if maxPayload == 0 {
+		maxPayload = DefaultMaxFramePayload
+	}
+
+	return &streamReader{
+		r:         stream.NewReader(resp.Body, maxPayload),
+		resp:      resp,
+		unmarshal: unmarshalFn,
+		cancel:    cancel,
+	}, nil
+}
+
+// DoBytes sends the request and returns the response body as an io.ReadCloser
+// for unstructured (octet-stream) responses. The caller must close the returned
+// ReadCloser when done.
+func (c *Client) DoBytes(ctx context.Context, req *http.Request) (io.ReadCloser, error) {
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, NewClientError("during client.Do(): %w", err, map[string]string{
+			DetailsHttpUrl:    req.URL.String(),
+			DetailsHttpMethod: req.Method,
+		})
+	}
+
+	if resp.StatusCode != CodeOK {
+		return nil, handleErrorResponse(req, resp)
+	}
+
+	ct := TrimSuffix(resp.Header.Get("Content-Type"), ";,")
+	ct = strings.TrimSpace(strings.ToLower(ct))
+
+	if ct != ContentOctetStream {
+		var body bytes.Buffer
+		_, _ = io.Copy(&body, resp.Body)
+		_ = resp.Body.Close()
+		return nil, NewInfraError(req, resp, body.Bytes())
+	}
+
+	return resp.Body, nil
+}
+
+// handleErrorResponse reads the response body and classifies the error based
+// on the content type and body contents. It closes the response body.
+func handleErrorResponse(req *http.Request, resp *http.Response) error {
+	defer func() { _ = resp.Body.Close() }()
+
+	var body bytes.Buffer
+	if _, err := io.Copy(&body, resp.Body); err != nil {
+		return &ClientError{
+			err: fmt.Errorf("while reading response body: %w", err),
+			details: map[string]string{
+				DetailsHttpUrl:    req.URL.String(),
+				DetailsHttpMethod: req.Method,
+				DetailsHttpStatus: resp.Status,
+			},
+			code:     strconv.Itoa(CodeClientError),
+			httpCode: CodeClientError,
+		}
+	}
+
+	ct := TrimSuffix(resp.Header.Get("Content-Type"), ";,")
+	switch strings.TrimSpace(strings.ToLower(ct)) {
+	case ContentTypeJSON:
+		var reply v1.Reply
+		if err := json.Unmarshal(body.Bytes(), &reply); err != nil {
+			return NewInfraError(req, resp, body.Bytes())
+		}
+		return NewReplyError(req, resp, &reply)
+	case ContentTypeProtoBuf:
+		var reply v1.Reply
+		if err := proto.Unmarshal(body.Bytes(), &reply); err != nil {
+			return NewInfraError(req, resp, body.Bytes())
+		}
+		return NewReplyError(req, resp, &reply)
+	default:
+		return NewInfraError(req, resp, body.Bytes())
 	}
 }

--- a/client.go
+++ b/client.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
@@ -96,7 +95,6 @@ var (
 // In the case of unexpected request or response errors, Do will return *duh.ClientError
 // with as much detail as possible.
 func (c *Client) Do(req *http.Request, out proto.Message) error {
-	// Preform the HTTP call
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return NewClientError("during client.Do(): %w", err, map[string]string{
@@ -104,10 +102,13 @@ func (c *Client) Do(req *http.Request, out proto.Message) error {
 			DetailsHttpMethod: req.Method,
 		})
 	}
+
+	if resp.StatusCode != CodeOK {
+		return handleErrorResponse(req, resp)
+	}
 	defer func() { _ = resp.Body.Close() }()
 
 	var body bytes.Buffer
-	// Copy the response into a buffer
 	if _, err = io.Copy(&body, resp.Body); err != nil {
 		return &ClientError{
 			err: fmt.Errorf("while reading response body: %w", err),
@@ -121,50 +122,22 @@ func (c *Client) Do(req *http.Request, out proto.Message) error {
 		}
 	}
 
-	// Handle content negotiation and un-marshal the response
-	mt := TrimSuffix(resp.Header.Get("Content-Type"), ";,")
-	switch strings.TrimSpace(strings.ToLower(mt)) {
+	switch normalizeMediaType(resp.Header.Get("Content-Type")) {
 	case ContentTypeJSON:
-		return c.handleJSONResponse(req, resp, body.Bytes(), out)
+		if err := json.Unmarshal(body.Bytes(), out); err != nil {
+			return NewClientError(
+				"", fmt.Errorf("while parsing response body '%s': %w", body.Bytes(), err), nil)
+		}
+		return nil
 	case ContentTypeProtoBuf:
-		return c.handleProtobufResponse(req, resp, body.Bytes(), out)
+		if err := proto.Unmarshal(body.Bytes(), out); err != nil {
+			return NewClientError(
+				"", fmt.Errorf("while parsing response body '%s': %w", body.Bytes(), err), nil)
+		}
+		return nil
 	default:
 		return NewInfraError(req, resp, body.Bytes())
 	}
-}
-
-func (c *Client) handleJSONResponse(req *http.Request, resp *http.Response, body []byte, out proto.Message) error {
-	if resp.StatusCode != CodeOK {
-		var reply v1.Reply
-		if err := json.Unmarshal(body, &reply); err != nil {
-			// Assume the body is not a Reply structure because
-			// the server is not respecting the spec.
-			return NewInfraError(req, resp, body)
-		}
-		return NewReplyError(req, resp, &reply)
-	}
-
-	if err := json.Unmarshal(body, out); err != nil {
-		return NewClientError(
-			"", fmt.Errorf("while parsing response body '%s': %w", body, err), nil)
-	}
-	return nil
-}
-
-func (c *Client) handleProtobufResponse(req *http.Request, resp *http.Response, body []byte, out proto.Message) error {
-	if resp.StatusCode != CodeOK {
-		var reply v1.Reply
-		if err := proto.Unmarshal(body, &reply); err != nil {
-			return NewInfraError(req, resp, body)
-		}
-		return NewReplyError(req, resp, &reply)
-	}
-
-	if err := proto.Unmarshal(body, out); err != nil {
-		return NewClientError(
-			"", fmt.Errorf("while parsing response body '%s': %w", body, err), nil)
-	}
-	return nil
 }
 
 // NewReplyError returns an error that originates from the service implementation, and does not originate from
@@ -256,11 +229,8 @@ func (c *Client) DoStream(ctx context.Context, req *http.Request) (StreamReader,
 		return nil, handleErrorResponse(req, resp)
 	}
 
-	ct := TrimSuffix(resp.Header.Get("Content-Type"), ";,")
-	ct = strings.TrimSpace(strings.ToLower(ct))
-
 	var unmarshalFn func([]byte, proto.Message) error
-	switch ct {
+	switch normalizeMediaType(resp.Header.Get("Content-Type")) {
 	case ContentStreamJSON:
 		unmarshalFn = json.Unmarshal
 	case ContentStreamProtoBuf:
@@ -302,10 +272,7 @@ func (c *Client) DoBytes(ctx context.Context, req *http.Request) (io.ReadCloser,
 		return nil, handleErrorResponse(req, resp)
 	}
 
-	ct := TrimSuffix(resp.Header.Get("Content-Type"), ";,")
-	ct = strings.TrimSpace(strings.ToLower(ct))
-
-	if ct != ContentOctetStream {
+	if normalizeMediaType(resp.Header.Get("Content-Type")) != ContentOctetStream {
 		var body bytes.Buffer
 		_, _ = io.Copy(&body, resp.Body)
 		_ = resp.Body.Close()
@@ -334,8 +301,7 @@ func handleErrorResponse(req *http.Request, resp *http.Response) error {
 		}
 	}
 
-	ct := TrimSuffix(resp.Header.Get("Content-Type"), ";,")
-	switch strings.TrimSpace(strings.ToLower(ct)) {
+	switch normalizeMediaType(resp.Header.Get("Content-Type")) {
 	case ContentTypeJSON:
 		var reply v1.Reply
 		if err := json.Unmarshal(body.Bytes(), &reply); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,8 +12,10 @@ import (
 
 	"github.com/duh-rpc/duh.go/v2"
 	"github.com/duh-rpc/duh.go/v2/internal/test"
+	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	json "google.golang.org/protobuf/encoding/protojson"
 )
 
 type badTransport struct {
@@ -205,4 +208,193 @@ func TestErrorInterface(t *testing.T) {
 	assert.Equal(t, "CARD_DECLINED", e.Code())
 	assert.Equal(t, duh.CodeRequestFailed, e.HTTPCode())
 	assert.Equal(t, "Request Failed:card was declined", e.Error())
+}
+
+func TestDoStreamErrors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	for _, tt := range []struct {
+		name     string
+		handler  http.HandlerFunc
+		wantCode int
+		isInfra  bool
+		checkMsg string
+	}{
+		{
+			name: "ServerReturns400WithReplyBody",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				reply := &v1.Reply{
+					Code:    "400",
+					Message: "bad request: missing field",
+				}
+				b, _ := json.Marshal(reply)
+				w.Header().Set("Content-Type", duh.ContentTypeJSON)
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(b)
+			},
+			wantCode: http.StatusBadRequest,
+			checkMsg: "bad request: missing field",
+		},
+		{
+			name: "ServerReturns502WithNonReplyBody",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte("upstream timeout"))
+			},
+			wantCode: http.StatusBadGateway,
+			isInfra:  true,
+			checkMsg: "upstream timeout",
+		},
+		{
+			name: "ServerReturns200WithWrongContentType",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("<html>oops</html>"))
+			},
+			wantCode: http.StatusOK,
+			isInfra:  true,
+			checkMsg: "<html>oops</html>",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			c := &duh.Client{Client: &http.Client{}}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test.stream", nil)
+			require.NoError(t, err)
+			req.Header.Set("Accept", duh.ContentStreamJSON)
+
+			sr, err := c.DoStream(ctx, req)
+			require.Error(t, err)
+			require.Nil(t, sr)
+
+			var ce *duh.ClientError
+			require.True(t, errors.As(err, &ce))
+			assert.Equal(t, tt.wantCode, ce.HTTPCode())
+			assert.Contains(t, ce.Message(), tt.checkMsg)
+			if tt.isInfra {
+				assert.True(t, ce.IsInfraError())
+			}
+		})
+	}
+
+	// Transport failure (bad URL)
+	t.Run("TransportFailure", func(t *testing.T) {
+		c := &duh.Client{Client: &http.Client{}}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost:1/v1/test.stream", nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept", duh.ContentStreamJSON)
+
+		sr, err := c.DoStream(ctx, req)
+		require.Error(t, err)
+		require.Nil(t, sr)
+
+		var ce *duh.ClientError
+		require.True(t, errors.As(err, &ce))
+		assert.Equal(t, duh.CodeClientError, ce.HTTPCode())
+	})
+}
+
+func TestDoBytesErrors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	for _, tt := range []struct {
+		name     string
+		handler  http.HandlerFunc
+		wantCode int
+		isInfra  bool
+		checkMsg string
+	}{
+		{
+			name: "ServerReturns400WithReplyBody",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				reply := &v1.Reply{
+					Code:    "400",
+					Message: "bad request: invalid params",
+				}
+				b, _ := json.Marshal(reply)
+				w.Header().Set("Content-Type", duh.ContentTypeJSON)
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(b)
+			},
+			wantCode: http.StatusBadRequest,
+			checkMsg: "bad request: invalid params",
+		},
+		{
+			name: "ServerReturns200WithWrongContentType",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("not binary data"))
+			},
+			wantCode: http.StatusOK,
+			isInfra:  true,
+			checkMsg: "not binary data",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			c := &duh.Client{Client: &http.Client{}}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/v1/bytes.download", nil)
+			require.NoError(t, err)
+			req.Header.Set("Accept", duh.ContentOctetStream)
+
+			rc, err := c.DoBytes(ctx, req)
+			require.Error(t, err)
+			require.Nil(t, rc)
+
+			var ce *duh.ClientError
+			require.True(t, errors.As(err, &ce))
+			assert.Equal(t, tt.wantCode, ce.HTTPCode())
+			assert.Contains(t, ce.Message(), tt.checkMsg)
+			if tt.isInfra {
+				assert.True(t, ce.IsInfraError())
+			}
+		})
+	}
+
+	// Success case: returns body as io.ReadCloser
+	t.Run("SuccessReturnsBody", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", duh.ContentOctetStream)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("hello, bytes"))
+		}))
+		defer server.Close()
+
+		c := &duh.Client{Client: &http.Client{}}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/v1/bytes.download", nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept", duh.ContentOctetStream)
+
+		rc, err := c.DoBytes(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, rc)
+
+		data, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, "hello, bytes", string(data))
+		require.NoError(t, rc.Close())
+	})
+
+	// Transport failure
+	t.Run("TransportFailure", func(t *testing.T) {
+		c := &duh.Client{Client: &http.Client{}}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:1/v1/bytes.download", nil)
+		require.NoError(t, err)
+
+		rc, err := c.DoBytes(ctx, req)
+		require.Error(t, err)
+		require.Nil(t, rc)
+
+		var ce *duh.ClientError
+		require.True(t, errors.As(err, &ce))
+		assert.Equal(t, duh.CodeClientError, ce.HTTPCode())
+	})
 }

--- a/demo/client.go
+++ b/demo/client.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/duh-rpc/duh.go/v2"
@@ -66,6 +67,36 @@ func (c *Client) SayHello(ctx context.Context, req *SayHelloRequest, resp *SayHe
 
 	// Do() will handle content negotiation, error handling, and un-marshal the response
 	return c.Do(r, resp)
+}
+
+// ListEvents sends a streaming request to the service which returns a stream of events.
+func (c *Client) ListEvents(ctx context.Context, req *ListEventsRequest) (duh.StreamReader, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, duh.NewClientError("while marshaling request payload: %w", err, nil)
+	}
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/%s", c.endpoint, "v1/events.list"), bytes.NewReader(payload))
+	if err != nil {
+		return nil, duh.NewClientError("", err, nil)
+	}
+
+	r.Header.Set("Content-Type", duh.ContentTypeJSON)
+	r.Header.Set("Accept", duh.ContentStreamJSON)
+	return c.DoStream(ctx, r)
+}
+
+// DownloadBytes demonstrates DoBytes by downloading an unstructured byte stream.
+func (c *Client) DownloadBytes(ctx context.Context) (io.ReadCloser, error) {
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/%s", c.endpoint, "v1/bytes.download"), nil)
+	if err != nil {
+		return nil, duh.NewClientError("", err, nil)
+	}
+
+	r.Header.Set("Accept", duh.ContentOctetStream)
+	return c.DoBytes(ctx, r)
 }
 
 // RenderPixel sends a request to the service which calculates the pixel color of a Mandelbrot

--- a/demo/demo.pb.go
+++ b/demo/demo.pb.go
@@ -254,6 +254,108 @@ func (x *RenderPixelResponse) GetGray() int64 {
 	return 0
 }
 
+type ListEventsRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Count int32 `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"` // Number of events to stream
+}
+
+func (x *ListEventsRequest) Reset() {
+	*x = ListEventsRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_demo_demo_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ListEventsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListEventsRequest) ProtoMessage() {}
+
+func (x *ListEventsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_demo_demo_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListEventsRequest.ProtoReflect.Descriptor instead.
+func (*ListEventsRequest) Descriptor() ([]byte, []int) {
+	return file_demo_demo_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ListEventsRequest) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
+type Event struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Sequence int64  `protobuf:"varint,1,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	Message  string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+}
+
+func (x *Event) Reset() {
+	*x = Event{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_demo_demo_proto_msgTypes[5]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Event) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Event) ProtoMessage() {}
+
+func (x *Event) ProtoReflect() protoreflect.Message {
+	mi := &file_demo_demo_proto_msgTypes[5]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Event.ProtoReflect.Descriptor instead.
+func (*Event) Descriptor() ([]byte, []int) {
+	return file_demo_demo_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *Event) GetSequence() int64 {
+	if x != nil {
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *Event) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 var File_demo_demo_proto protoreflect.FileDescriptor
 
 var file_demo_demo_proto_rawDesc = []byte{
@@ -274,10 +376,16 @@ var file_demo_demo_proto_rawDesc = []byte{
 	0x12, 0x0c, 0x0a, 0x01, 0x6a, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x52, 0x01, 0x6a, 0x22, 0x29,
 	0x0a, 0x13, 0x52, 0x65, 0x6e, 0x64, 0x65, 0x72, 0x50, 0x69, 0x78, 0x65, 0x6c, 0x52, 0x65, 0x73,
 	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x67, 0x72, 0x61, 0x79, 0x18, 0x01, 0x20,
-	0x01, 0x28, 0x03, 0x52, 0x04, 0x67, 0x72, 0x61, 0x79, 0x42, 0x23, 0x5a, 0x21, 0x67, 0x69, 0x74,
-	0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x64, 0x75, 0x68, 0x2d, 0x72, 0x70, 0x63, 0x2f,
-	0x64, 0x75, 0x68, 0x2e, 0x67, 0x6f, 0x2f, 0x76, 0x32, 0x2f, 0x64, 0x65, 0x6d, 0x6f, 0x62, 0x06,
-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x01, 0x28, 0x03, 0x52, 0x04, 0x67, 0x72, 0x61, 0x79, 0x22, 0x29, 0x0a, 0x11, 0x4c, 0x69, 0x73,
+	0x74, 0x45, 0x76, 0x65, 0x6e, 0x74, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x14,
+	0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x63,
+	0x6f, 0x75, 0x6e, 0x74, 0x22, 0x3d, 0x0a, 0x05, 0x45, 0x76, 0x65, 0x6e, 0x74, 0x12, 0x1a, 0x0a,
+	0x08, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52,
+	0x08, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x6d, 0x65, 0x73,
+	0x73, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x6d, 0x65, 0x73, 0x73,
+	0x61, 0x67, 0x65, 0x42, 0x23, 0x5a, 0x21, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
+	0x6d, 0x2f, 0x64, 0x75, 0x68, 0x2d, 0x72, 0x70, 0x63, 0x2f, 0x64, 0x75, 0x68, 0x2e, 0x67, 0x6f,
+	0x2f, 0x76, 0x32, 0x2f, 0x64, 0x65, 0x6d, 0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -292,12 +400,14 @@ func file_demo_demo_proto_rawDescGZIP() []byte {
 	return file_demo_demo_proto_rawDescData
 }
 
-var file_demo_demo_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_demo_demo_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_demo_demo_proto_goTypes = []interface{}{
 	(*SayHelloRequest)(nil),     // 0: duh.v1.SayHelloRequest
 	(*SayHelloResponse)(nil),    // 1: duh.v1.SayHelloResponse
 	(*RenderPixelRequest)(nil),  // 2: duh.v1.RenderPixelRequest
 	(*RenderPixelResponse)(nil), // 3: duh.v1.RenderPixelResponse
+	(*ListEventsRequest)(nil),   // 4: duh.v1.ListEventsRequest
+	(*Event)(nil),               // 5: duh.v1.Event
 }
 var file_demo_demo_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -361,6 +471,30 @@ func file_demo_demo_proto_init() {
 				return nil
 			}
 		}
+		file_demo_demo_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ListEventsRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_demo_demo_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*Event); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -368,7 +502,7 @@ func file_demo_demo_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_demo_demo_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/demo/demo.proto
+++ b/demo/demo.proto
@@ -38,3 +38,12 @@ message RenderPixelResponse {
   // Gray represents an 8-bit grayscale color.
   int64 gray = 1;
 }
+
+message ListEventsRequest {
+  int32 count = 1;  // Number of events to stream
+}
+
+message Event {
+  int64 sequence = 1;
+  string message = 2;
+}

--- a/demo/handler.go
+++ b/demo/handler.go
@@ -47,6 +47,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/v1/render.pixel":
 		h.handleRenderPixel(w, r)
 		return
+	case "/v1/events.list":
+		duh.HandleStream(w, r, h.listEvents)
+		return
+	case "/v1/bytes.download":
+		h.handleDownloadBytes(w, r)
+		return
 	}
 	duh.ReplyWithCode(w, r, duh.CodeNotImplemented, nil, "no such method; "+r.URL.Path)
 }
@@ -64,6 +70,32 @@ func (h *Handler) handleSayHello(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	duh.Reply(w, r, duh.CodeOK, &resp)
+}
+
+func (h *Handler) listEvents(r *http.Request, stream duh.StreamWriter) error {
+	var req ListEventsRequest
+	if err := duh.ReadRequest(r, &req, 5*duh.MegaByte); err != nil {
+		return err
+	}
+
+	events, err := h.Service.ListEvents(r.Context(), &req)
+	if err != nil {
+		return err
+	}
+
+	for _, event := range events {
+		if err := stream.Send(event); err != nil {
+			return err
+		}
+	}
+
+	return stream.Close(nil)
+}
+
+func (h *Handler) handleDownloadBytes(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", duh.ContentOctetStream)
+	w.WriteHeader(duh.CodeOK)
+	_, _ = w.Write([]byte("hello, bytes"))
 }
 
 func (h *Handler) handleRenderPixel(w http.ResponseWriter, r *http.Request) {

--- a/demo/service.go
+++ b/demo/service.go
@@ -65,6 +65,18 @@ func (h *Service) RenderPixel(ctx context.Context, req *RenderPixelRequest, resp
 	return nil
 }
 
+// ListEvents generates a list of events to be streamed to the client.
+func (h *Service) ListEvents(ctx context.Context, req *ListEventsRequest) ([]*Event, error) {
+	events := make([]*Event, 0, req.Count)
+	for i := int32(0); i < req.Count; i++ {
+		events = append(events, &Event{
+			Sequence: int64(i),
+			Message:  fmt.Sprintf("event-%d", i),
+		})
+	}
+	return events, nil
+}
+
 func norm(x, total int64, min, max float64) float64 {
 	return (max-min)*float64(x)/float64(total) - max
 }

--- a/docs/ai-cheatsheet.md
+++ b/docs/ai-cheatsheet.md
@@ -198,7 +198,7 @@ An endpoint is paginated if its response has `items` + `pagination`. Actions lik
 ## Schema Rules
 
 - Every operation MUST have a dedicated request schema and a dedicated response schema. No sharing across operations.
-- Name schemas after their operation: `CreateUserRequest`, `CreateUserResponse`.
+- Name schemas after their operation: `UserCreateRequest`, `UserCreateResponse`.
 - No `readOnly` or `writeOnly` field annotations. Put fields in the correct schema instead.
 
 ### Protobuf Compatibility Constraints

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -331,7 +331,7 @@ A `429` that does not include a Reply body MUST be treated as an infrastructure-
 ### Request and Response Schemas
 Every operation MUST define a dedicated request schema and a dedicated response schema. Schemas MUST NOT be shared across operations. This ensures each operation has a clear, unambiguous contract and maps cleanly to generated code and protobuf message definitions.
 
-By convention, schemas are named after the operation they belong to, e.g. `CreateUserRequest` and `CreateUserResponse`, though any consistent naming convention is acceptable (camelCase, snake_case, or kebab-case). Tooling that generates protobuf definitions will normalize names to the appropriate convention.
+By convention, schemas are named after the operation they belong to, e.g. `UserCreateRequest` and `UserCreateResponse`, though any consistent naming convention is acceptable (camelCase, snake_case, or kebab-case). Tooling that generates protobuf definitions will normalize names to the appropriate convention.
 
 ### Streaming Endpoints
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -349,6 +349,52 @@ func TestStreamingContextCancel(t *testing.T) {
 	assert.Equal(t, io.EOF, sr.Recv(&item))
 }
 
+func TestStreamingCorruptDataFrame(t *testing.T) {
+	// Server writes one valid data frame, then a data frame with invalid JSON payload
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", duh.ContentStreamJSON)
+
+		sw := stream.NewWriter(w)
+		valid, _ := json.Marshal(&test.StreamItem{Sequence: 0, Data: "good"})
+		_ = sw.WriteFrame(stream.FlagData, valid)
+		_ = sw.WriteFrame(stream.FlagData, []byte("not valid json{{{"))
+		_ = sw.WriteFrame(stream.FlagFinal, nil)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	// First Recv succeeds
+	var item test.StreamItem
+	require.NoError(t, sr.Recv(&item))
+	assert.Equal(t, int64(0), item.Sequence)
+
+	// Second Recv fails due to corrupt payload
+	err = sr.Recv(&item)
+	require.Error(t, err)
+
+	// Subsequent Recv returns EOF (stream is done, not retried)
+	assert.Equal(t, io.EOF, sr.Recv(&item))
+
+	require.NoError(t, sr.Close())
+}
+
 func TestDoBytesHappyPath(t *testing.T) {
 	service := demo.NewService()
 	server := httptest.NewServer(&demo.Handler{Service: service})

--- a/functional_test.go
+++ b/functional_test.go
@@ -15,6 +15,7 @@ limitations under the License.
 package duh_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -194,11 +195,7 @@ func TestStreamingBadAcceptHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		server.URL+"/v1/test.stream", io.NopCloser(
-			io.NewSectionReader(
-				readerAtFromBytes(payload), 0, int64(len(payload)),
-			),
-		))
+		server.URL+"/v1/test.stream", bytes.NewReader(payload))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", duh.ContentTypeJSON)
 	req.Header.Set("Accept", duh.ContentTypeJSON)
@@ -212,26 +209,6 @@ func TestStreamingBadAcceptHeader(t *testing.T) {
 	require.True(t, errors.As(err, &duhErr))
 	assert.Equal(t, http.StatusBadRequest, duhErr.HTTPCode())
 	assert.Contains(t, duhErr.Message(), "Accept header")
-}
-
-// readerAtFromBytes creates a bytes.Reader that implements io.ReaderAt.
-func readerAtFromBytes(b []byte) *bytesReaderAt {
-	return &bytesReaderAt{data: b}
-}
-
-type bytesReaderAt struct {
-	data []byte
-}
-
-func (r *bytesReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
-	if off >= int64(len(r.data)) {
-		return 0, io.EOF
-	}
-	n = copy(p, r.data[off:])
-	if n < len(p) {
-		err = io.EOF
-	}
-	return
 }
 
 func TestStreamingSendAfterClose(t *testing.T) {
@@ -275,7 +252,7 @@ func TestStreamingSendAfterClose(t *testing.T) {
 	// Verify the server-side Send after Close returned an error
 	serverErr := <-sendErr
 	require.Error(t, serverErr)
-	assert.Contains(t, serverErr.Error(), "stream is closed")
+	assert.ErrorIs(t, serverErr, duh.ErrStreamClosed)
 }
 
 func TestStreamingServerDisconnect(t *testing.T) {

--- a/functional_test.go
+++ b/functional_test.go
@@ -204,7 +204,7 @@ func TestStreamingBadAcceptHeader(t *testing.T) {
 	req.Header.Set("Accept", duh.ContentTypeJSON)
 
 	// DoStream should return an error because the server returns a 400 Reply
-	sr, err := c.Client.DoStream(ctx, req)
+	sr, err := c.DoStream(ctx, req)
 	require.Error(t, err)
 	require.Nil(t, sr)
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -16,12 +16,21 @@ package duh_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/duh-rpc/duh.go/v2"
 	"github.com/duh-rpc/duh.go/v2/demo"
+	"github.com/duh-rpc/duh.go/v2/internal/test"
+	"github.com/duh-rpc/duh.go/v2/stream"
 	"github.com/stretchr/testify/assert"
-	"net/http/httptest"
+	"github.com/stretchr/testify/require"
+	json "google.golang.org/protobuf/encoding/protojson"
 )
 
 func TestDemoHappyPath(t *testing.T) {
@@ -64,7 +73,324 @@ func TestDemoHappyPath(t *testing.T) {
 	}
 }
 
-// TODO: Client example of passing `application/octet-stream` with `duh.DoBytes()`
+func TestStreamingHappyPath(t *testing.T) {
+	service := test.NewService()
+	server := httptest.NewServer(&test.Handler{Service: service})
+	defer server.Close()
+
+	c := test.NewClient(test.ClientConfig{Endpoint: server.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	sr, err := c.TestStream(ctx, &test.StreamRequest{Count: 5})
+	require.NoError(t, err)
+
+	// Collect all items
+	var items []*test.StreamItem
+	for {
+		var item test.StreamItem
+		err := sr.Recv(&item)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		items = append(items, &item)
+	}
+
+	require.Len(t, items, 5)
+	for i, item := range items {
+		assert.Equal(t, int64(i), item.Sequence)
+		assert.Equal(t, fmt.Sprintf("item-%d", i), item.Data)
+	}
+
+	// Verify subsequent Recv returns EOF
+	var extra test.StreamItem
+	assert.Equal(t, io.EOF, sr.Recv(&extra))
+
+	// Close is safe to call after EOF
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamingErrorFrame(t *testing.T) {
+	service := test.NewService()
+	server := httptest.NewServer(&test.Handler{Service: service})
+	defer server.Close()
+
+	c := test.NewClient(test.ClientConfig{Endpoint: server.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	sr, err := c.TestStream(ctx, &test.StreamRequest{
+		Count:   3,
+		ErrorAt: "database connection lost",
+	})
+	require.NoError(t, err)
+
+	// Receive 3 data frames successfully
+	for i := 0; i < 3; i++ {
+		var item test.StreamItem
+		require.NoError(t, sr.Recv(&item))
+		assert.Equal(t, int64(i), item.Sequence)
+	}
+
+	// Next Recv returns the error frame
+	var item test.StreamItem
+	err = sr.Recv(&item)
+	require.Error(t, err)
+
+	var duhErr duh.Error
+	require.True(t, errors.As(err, &duhErr))
+	assert.Equal(t, "500", duhErr.Code())
+	assert.Contains(t, duhErr.Message(), "database connection lost")
+
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamingCloseWithPayload(t *testing.T) {
+	service := test.NewService()
+	server := httptest.NewServer(&test.Handler{Service: service})
+	defer server.Close()
+
+	c := test.NewClient(test.ClientConfig{Endpoint: server.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	sr, err := c.TestStream(ctx, &test.StreamRequest{
+		Count:            2,
+		CloseWithPayload: true,
+	})
+	require.NoError(t, err)
+
+	// Receive 2 data frames
+	for i := 0; i < 2; i++ {
+		var item test.StreamItem
+		require.NoError(t, sr.Recv(&item))
+		assert.Equal(t, int64(i), item.Sequence)
+	}
+
+	// Receive the final frame payload (3rd Recv returns nil error with the payload)
+	var finalItem test.StreamItem
+	require.NoError(t, sr.Recv(&finalItem))
+	assert.Equal(t, int64(2), finalItem.Sequence)
+
+	// Next Recv returns EOF
+	var extra test.StreamItem
+	assert.Equal(t, io.EOF, sr.Recv(&extra))
+
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamingBadAcceptHeader(t *testing.T) {
+	service := test.NewService()
+	server := httptest.NewServer(&test.Handler{Service: service})
+	defer server.Close()
+
+	c := test.NewClient(test.ClientConfig{Endpoint: server.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	// Manually construct a request with a non-stream Accept header
+	payload, err := json.Marshal(&test.StreamRequest{Count: 1})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		server.URL+"/v1/test.stream", io.NopCloser(
+			io.NewSectionReader(
+				readerAtFromBytes(payload), 0, int64(len(payload)),
+			),
+		))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", duh.ContentTypeJSON)
+	req.Header.Set("Accept", duh.ContentTypeJSON)
+
+	// DoStream should return an error because the server returns a 400 Reply
+	sr, err := c.Client.DoStream(ctx, req)
+	require.Error(t, err)
+	require.Nil(t, sr)
+
+	var duhErr *duh.ClientError
+	require.True(t, errors.As(err, &duhErr))
+	assert.Equal(t, http.StatusBadRequest, duhErr.HTTPCode())
+	assert.Contains(t, duhErr.Message(), "Accept header")
+}
+
+// readerAtFromBytes creates a bytes.Reader that implements io.ReaderAt.
+func readerAtFromBytes(b []byte) *bytesReaderAt {
+	return &bytesReaderAt{data: b}
+}
+
+type bytesReaderAt struct {
+	data []byte
+}
+
+func (r *bytesReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	if off >= int64(len(r.data)) {
+		return 0, io.EOF
+	}
+	n = copy(p, r.data[off:])
+	if n < len(p) {
+		err = io.EOF
+	}
+	return
+}
+
+func TestStreamingSendAfterClose(t *testing.T) {
+	// Channel to capture the Send-after-Close error from the handler
+	sendErr := make(chan error, 1)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleStream(w, r, func(r *http.Request, sw duh.StreamWriter) error {
+			// Close the stream immediately
+			if err := sw.Close(nil); err != nil {
+				sendErr <- fmt.Errorf("close failed: %w", err)
+				return err
+			}
+
+			// Attempt to Send after Close -- should fail
+			sendErr <- sw.Send(&test.StreamItem{Sequence: 1, Data: "after-close"})
+			return nil
+		})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	// Client receives EOF because the stream was closed with nil payload
+	var item test.StreamItem
+	assert.Equal(t, io.EOF, sr.Recv(&item))
+	require.NoError(t, sr.Close())
+
+	// Verify the server-side Send after Close returned an error
+	serverErr := <-sendErr
+	require.Error(t, serverErr)
+	assert.Contains(t, serverErr.Error(), "stream is closed")
+}
+
+func TestStreamingServerDisconnect(t *testing.T) {
+	// Raw handler that writes one data frame but doesn't write a final frame
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", duh.ContentStreamJSON)
+
+		sw := stream.NewWriter(w)
+		payload, _ := json.Marshal(&test.StreamItem{Sequence: 0, Data: "only-item"})
+		_ = sw.WriteFrame(stream.FlagData, payload)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Return without writing a final frame -- connection closes
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	// First Recv succeeds
+	var item test.StreamItem
+	require.NoError(t, sr.Recv(&item))
+	assert.Equal(t, int64(0), item.Sequence)
+	assert.Equal(t, "only-item", item.Data)
+
+	// Second Recv returns io.ErrUnexpectedEOF because no final frame was sent
+	err = sr.Recv(&item)
+	assert.Equal(t, io.ErrUnexpectedEOF, err)
+
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamingContextCancel(t *testing.T) {
+	// Handler that sends frames with a delay between each
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleStream(w, r, func(r *http.Request, sw duh.StreamWriter) error {
+			for i := 0; i < 100; i++ {
+				if err := sw.Send(&test.StreamItem{
+					Sequence: int64(i),
+					Data:     fmt.Sprintf("item-%d", i),
+				}); err != nil {
+					return err
+				}
+				select {
+				case <-sw.Context().Done():
+					return sw.Context().Err()
+				case <-time.After(50 * time.Millisecond):
+				}
+			}
+			return sw.Close(nil)
+		})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	// Read 2 frames
+	for i := 0; i < 2; i++ {
+		var item test.StreamItem
+		require.NoError(t, sr.Recv(&item))
+		assert.Equal(t, int64(i), item.Sequence)
+	}
+
+	// Cancel the context by closing the stream reader (which cancels the child context)
+	require.NoError(t, sr.Close())
+
+	// Subsequent Recv should return EOF (since we closed)
+	var item test.StreamItem
+	assert.Equal(t, io.EOF, sr.Recv(&item))
+}
+
+func TestDoBytesHappyPath(t *testing.T) {
+	service := demo.NewService()
+	server := httptest.NewServer(&demo.Handler{Service: service})
+	defer server.Close()
+
+	c := demo.NewClient(demo.ClientConfig{Endpoint: server.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	rc, err := c.DownloadBytes(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rc)
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "hello, bytes", string(data))
+	require.NoError(t, rc.Close())
+}
+
 // TODO: Update the benchmark tests
 
 // TODO: DUH-RPC Validation Test for any endpoint

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -18,9 +18,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/duh-rpc/duh.go/v2"
-	"google.golang.org/protobuf/proto"
 	"net/http"
+
+	"github.com/duh-rpc/duh.go/v2"
+	json "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // Client is a simple client that calls the Service
@@ -44,6 +46,24 @@ func NewClient(conf ClientConfig) *Client {
 		},
 		endpoint: conf.Endpoint,
 	}
+}
+
+// TestStream sends a streaming request and returns a StreamReader.
+func (c *Client) TestStream(ctx context.Context, req *StreamRequest) (duh.StreamReader, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, duh.NewClientError("while marshaling request payload: %w", err, nil)
+	}
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/%s", c.endpoint, "v1/test.stream"), bytes.NewReader(payload))
+	if err != nil {
+		return nil, duh.NewClientError("", err, nil)
+	}
+
+	r.Header.Set("Content-Type", duh.ContentTypeJSON)
+	r.Header.Set("Accept", duh.ContentStreamJSON)
+	return c.DoStream(ctx, r)
 }
 
 // TestErrors is used in test suite to test error handling

--- a/internal/test/handler.go
+++ b/internal/test/handler.go
@@ -47,21 +47,16 @@ func (h *Handler) handleTestStream(r *http.Request, stream duh.StreamWriter) err
 	}
 
 	items, err := h.Service.TestStream(r.Context(), &req)
-	if err != nil {
-		// Send the data frames first, then return the error so HandleStream
-		// writes an error frame.
-		for _, item := range items {
-			if sendErr := stream.Send(item); sendErr != nil {
-				return sendErr
-			}
+
+	// Send all data frames before handling error or close
+	for _, item := range items {
+		if sendErr := stream.Send(item); sendErr != nil {
+			return sendErr
 		}
-		return err
 	}
 
-	for _, item := range items {
-		if err := stream.Send(item); err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
 	if req.CloseWithPayload {

--- a/internal/test/handler.go
+++ b/internal/test/handler.go
@@ -33,8 +33,41 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/v1/test.errors":
 		h.handleTestErrors(w, r)
 		return
+	case "/v1/test.stream":
+		duh.HandleStream(w, r, h.handleTestStream)
+		return
 	}
 	duh.ReplyWithCode(w, r, duh.CodeNotImplemented, nil, "no such method; "+r.URL.Path)
+}
+
+func (h *Handler) handleTestStream(r *http.Request, stream duh.StreamWriter) error {
+	var req StreamRequest
+	if err := duh.ReadRequest(r, &req, 5*duh.MegaByte); err != nil {
+		return err
+	}
+
+	items, err := h.Service.TestStream(r.Context(), &req)
+	if err != nil {
+		// Send the data frames first, then return the error so HandleStream
+		// writes an error frame.
+		for _, item := range items {
+			if sendErr := stream.Send(item); sendErr != nil {
+				return sendErr
+			}
+		}
+		return err
+	}
+
+	for _, item := range items {
+		if err := stream.Send(item); err != nil {
+			return err
+		}
+	}
+
+	if req.CloseWithPayload {
+		return stream.Close(&StreamItem{Sequence: int64(req.Count)})
+	}
+	return stream.Close(nil)
 }
 
 func (h *Handler) handleTestErrors(w http.ResponseWriter, r *http.Request) {

--- a/internal/test/service.go
+++ b/internal/test/service.go
@@ -16,6 +16,8 @@ package test
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/duh-rpc/duh.go/v2"
 )
 
@@ -37,4 +39,22 @@ func (h *Service) TestErrors(ctx context.Context, req *ErrorsRequest) error {
 	}
 
 	return nil
+}
+
+// TestStream generates a list of items for streaming. If ErrorAt is set, it returns
+// an error after generating all items.
+func (h *Service) TestStream(ctx context.Context, req *StreamRequest) ([]*StreamItem, error) {
+	items := make([]*StreamItem, 0, req.Count)
+	for i := int32(0); i < req.Count; i++ {
+		items = append(items, &StreamItem{
+			Sequence: int64(i),
+			Data:     fmt.Sprintf("item-%d", i),
+		})
+	}
+
+	if req.ErrorAt != "" {
+		return items, duh.NewServiceError(duh.CodeInternalError, req.ErrorAt, nil, nil)
+	}
+
+	return items, nil
 }

--- a/internal/test/test.pb.go
+++ b/internal/test/test.pb.go
@@ -80,6 +80,124 @@ func (x *ErrorsRequest) GetCase() string {
 	return ""
 }
 
+type StreamRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Count            int32  `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"`                                                 // Number of data frames to send
+	ErrorAt          string `protobuf:"bytes,2,opt,name=error_at,json=errorAt,proto3" json:"error_at,omitempty"`                               // If set, return this error after sending 'count' frames
+	CloseWithPayload bool   `protobuf:"varint,3,opt,name=close_with_payload,json=closeWithPayload,proto3" json:"close_with_payload,omitempty"` // If true, close with a payload in the final frame
+}
+
+func (x *StreamRequest) Reset() {
+	*x = StreamRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_test_test_proto_msgTypes[1]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *StreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamRequest) ProtoMessage() {}
+
+func (x *StreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_test_test_proto_msgTypes[1]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamRequest.ProtoReflect.Descriptor instead.
+func (*StreamRequest) Descriptor() ([]byte, []int) {
+	return file_internal_test_test_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *StreamRequest) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
+func (x *StreamRequest) GetErrorAt() string {
+	if x != nil {
+		return x.ErrorAt
+	}
+	return ""
+}
+
+func (x *StreamRequest) GetCloseWithPayload() bool {
+	if x != nil {
+		return x.CloseWithPayload
+	}
+	return false
+}
+
+type StreamItem struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Sequence int64  `protobuf:"varint,1,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	Data     string `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+}
+
+func (x *StreamItem) Reset() {
+	*x = StreamItem{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_test_test_proto_msgTypes[2]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *StreamItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamItem) ProtoMessage() {}
+
+func (x *StreamItem) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_test_test_proto_msgTypes[2]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamItem.ProtoReflect.Descriptor instead.
+func (*StreamItem) Descriptor() ([]byte, []int) {
+	return file_internal_test_test_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *StreamItem) GetSequence() int64 {
+	if x != nil {
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *StreamItem) GetData() string {
+	if x != nil {
+		return x.Data
+	}
+	return ""
+}
+
 var File_internal_test_test_proto protoreflect.FileDescriptor
 
 var file_internal_test_test_proto_rawDesc = []byte{
@@ -87,10 +205,21 @@ var file_internal_test_test_proto_rawDesc = []byte{
 	0x74, 0x65, 0x73, 0x74, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x06, 0x64, 0x75, 0x68, 0x2e,
 	0x76, 0x31, 0x22, 0x23, 0x0a, 0x0d, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x73, 0x52, 0x65, 0x71, 0x75,
 	0x65, 0x73, 0x74, 0x12, 0x12, 0x0a, 0x04, 0x63, 0x61, 0x73, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28,
-	0x09, 0x52, 0x04, 0x63, 0x61, 0x73, 0x65, 0x42, 0x2c, 0x5a, 0x2a, 0x67, 0x69, 0x74, 0x68, 0x75,
-	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x64, 0x75, 0x68, 0x2d, 0x72, 0x70, 0x63, 0x2f, 0x64, 0x75,
-	0x68, 0x2e, 0x67, 0x6f, 0x2f, 0x76, 0x32, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c,
-	0x2f, 0x74, 0x65, 0x73, 0x74, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x09, 0x52, 0x04, 0x63, 0x61, 0x73, 0x65, 0x22, 0x6e, 0x0a, 0x0d, 0x53, 0x74, 0x72, 0x65, 0x61,
+	0x6d, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x14, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e,
+	0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x12, 0x19,
+	0x0a, 0x08, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x61, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x07, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x41, 0x74, 0x12, 0x2c, 0x0a, 0x12, 0x63, 0x6c, 0x6f,
+	0x73, 0x65, 0x5f, 0x77, 0x69, 0x74, 0x68, 0x5f, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x08, 0x52, 0x10, 0x63, 0x6c, 0x6f, 0x73, 0x65, 0x57, 0x69, 0x74, 0x68,
+	0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x22, 0x3c, 0x0a, 0x0a, 0x53, 0x74, 0x72, 0x65, 0x61,
+	0x6d, 0x49, 0x74, 0x65, 0x6d, 0x12, 0x1a, 0x0a, 0x08, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63,
+	0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52, 0x08, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63,
+	0x65, 0x12, 0x12, 0x0a, 0x04, 0x64, 0x61, 0x74, 0x61, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x04, 0x64, 0x61, 0x74, 0x61, 0x42, 0x2c, 0x5a, 0x2a, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e,
+	0x63, 0x6f, 0x6d, 0x2f, 0x64, 0x75, 0x68, 0x2d, 0x72, 0x70, 0x63, 0x2f, 0x64, 0x75, 0x68, 0x2e,
+	0x67, 0x6f, 0x2f, 0x76, 0x32, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x74,
+	0x65, 0x73, 0x74, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -105,9 +234,11 @@ func file_internal_test_test_proto_rawDescGZIP() []byte {
 	return file_internal_test_test_proto_rawDescData
 }
 
-var file_internal_test_test_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_internal_test_test_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_internal_test_test_proto_goTypes = []interface{}{
 	(*ErrorsRequest)(nil), // 0: duh.v1.ErrorsRequest
+	(*StreamRequest)(nil), // 1: duh.v1.StreamRequest
+	(*StreamItem)(nil),    // 2: duh.v1.StreamItem
 }
 var file_internal_test_test_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -135,6 +266,30 @@ func file_internal_test_test_proto_init() {
 				return nil
 			}
 		}
+		file_internal_test_test_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StreamRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_internal_test_test_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StreamItem); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -142,7 +297,7 @@ func file_internal_test_test_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_internal_test_test_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/test/test.proto
+++ b/internal/test/test.proto
@@ -21,3 +21,14 @@ option go_package = "github.com/duh-rpc/duh.go/v2/internal/test";
 message ErrorsRequest {
   string case = 1;
 }
+
+message StreamRequest {
+  int32 count = 1;              // Number of data frames to send
+  string error_at = 2;          // If set, return this error after sending 'count' frames
+  bool close_with_payload = 3;  // If true, close with a payload in the final frame
+}
+
+message StreamItem {
+  int64 sequence = 1;
+  string data = 2;
+}

--- a/service.go
+++ b/service.go
@@ -61,10 +61,7 @@ func ReadRequest(r *http.Request, m proto.Message, limit int64) error {
 		return NewServiceError(CodeInternalError, "", err, nil)
 	}
 
-	// Ignore multiple mime types separated by comma ',' or mime type parameters separated by semicolon ';'
-	mimeType := TrimSuffix(r.Header.Get("Content-Type"), ";,")
-
-	switch strings.TrimSpace(strings.ToLower(mimeType)) {
+	switch normalizeMediaType(r.Header.Get("Content-Type")) {
 	case "", "*/*", "application/*", ContentTypeJSON:
 		if err := json.Unmarshal(b.Bytes(), m); err != nil {
 			return NewServiceError(CodeClientContentError, "", err, nil)
@@ -108,10 +105,9 @@ func ReplyError(w http.ResponseWriter, r *http.Request, err error) {
 // Reply() provides content negotiation for protobuf if the request has the 'Accept' header set.
 // If no 'Accept' header was provided, Reply() will marshall the proto.Message into JSON.
 func Reply(w http.ResponseWriter, r *http.Request, code int, resp proto.Message) {
-	// Ignore multiple mime types separated by comma ',' or mime type parameters separated by semicolon ';'
-	mimeType := TrimSuffix(r.Header.Get("Accept"), ";,")
+	mimeType := normalizeMediaType(r.Header.Get("Accept"))
 
-	switch strings.TrimSpace(strings.ToLower(mimeType)) {
+	switch mimeType {
 	case "", "*/*", "application/*", ContentTypeJSON:
 		b, err := json.Marshal(resp)
 		if err != nil {
@@ -148,4 +144,10 @@ func TrimSuffix(s, sep string) string {
 		return s[:i]
 	}
 	return s
+}
+
+// normalizeMediaType strips MIME parameters (after ';' or ','), trims whitespace,
+// and lowercases the result, producing a canonical media type for comparison.
+func normalizeMediaType(value string) string {
+	return strings.TrimSpace(strings.ToLower(TrimSuffix(value, ";,")))
 }

--- a/service.go
+++ b/service.go
@@ -29,9 +29,11 @@ import (
 )
 
 const (
-	ContentTypeProtoBuf = "application/protobuf"
-	ContentTypeJSON     = "application/json"
-	ContentOctetStream  = "application/octet-stream"
+	ContentTypeProtoBuf   = "application/protobuf"
+	ContentTypeJSON       = "application/json"
+	ContentOctetStream    = "application/octet-stream"
+	ContentStreamJSON     = "application/duh-stream+json"
+	ContentStreamProtoBuf = "application/duh-stream+protobuf"
 )
 
 var (

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -1,0 +1,92 @@
+package stream
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const (
+	FlagData  byte = 0x0
+	FlagFinal byte = 0x1
+	FlagError byte = 0x2
+)
+
+// headerSize is the size of a frame header: 1 byte flag + 4 bytes uint32 length.
+const headerSize = 5
+
+// Writer encodes length-prefixed binary frames to an io.Writer.
+type Writer struct {
+	w io.Writer
+}
+
+// NewWriter wraps an io.Writer for frame encoding.
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{w: w}
+}
+
+// WriteFrame writes a single frame: [1 byte flag][4 bytes uint32 big-endian length][N bytes payload].
+// A final frame with nil/empty payload writes length 0x00000000.
+func (w *Writer) WriteFrame(flag byte, payload []byte) error {
+	var header [headerSize]byte
+	header[0] = flag
+	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
+
+	if _, err := w.w.Write(header[:]); err != nil {
+		return err
+	}
+	if len(payload) > 0 {
+		if _, err := w.w.Write(payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Reader decodes length-prefixed binary frames from an io.Reader.
+type Reader struct {
+	r              io.Reader
+	maxPayloadSize int
+}
+
+// NewReader wraps an io.Reader with a maximum payload size. If maxPayloadSize
+// is 0, no limit is enforced.
+func NewReader(r io.Reader, maxPayloadSize int) *Reader {
+	return &Reader{r: r, maxPayloadSize: maxPayloadSize}
+}
+
+// ReadFrame reads one frame from the underlying reader. It returns the flag byte,
+// the payload, and any error. Returns io.EOF when the reader is exhausted at a
+// frame boundary. Returns io.ErrUnexpectedEOF if the reader is exhausted mid-frame.
+func (r *Reader) ReadFrame() (flag byte, payload []byte, err error) {
+	var header [headerSize]byte
+	_, err = io.ReadFull(r.r, header[:])
+	if err != nil {
+		if err == io.EOF {
+			// Exhausted at frame boundary (before reading any header bytes)
+			return 0, nil, io.EOF
+		}
+		// Partial header read (io.ErrUnexpectedEOF from ReadFull)
+		return 0, nil, io.ErrUnexpectedEOF
+	}
+
+	flag = header[0]
+	length := binary.BigEndian.Uint32(header[1:])
+
+	if r.maxPayloadSize > 0 && int(length) > r.maxPayloadSize {
+		return 0, nil, fmt.Errorf("frame payload size %d exceeds limit %d", length, r.maxPayloadSize)
+	}
+
+	if length == 0 {
+		return flag, nil, nil
+	}
+
+	payload = make([]byte, length)
+	_, err = io.ReadFull(r.r, payload)
+	if err != nil {
+		// Partial payload read
+		return 0, nil, io.ErrUnexpectedEOF
+	}
+
+	return flag, payload, nil
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1,0 +1,150 @@
+package stream_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/duh-rpc/duh.go/v2/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	// Write a data frame, read it back
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	r := stream.NewReader(&buf, 0)
+
+	require.NoError(t, w.WriteFrame(stream.FlagData, []byte("hello")))
+	flag, payload, err := r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagData, flag)
+	assert.Equal(t, []byte("hello"), payload)
+
+	// Write a final frame with payload, read it back
+	buf.Reset()
+	require.NoError(t, w.WriteFrame(stream.FlagFinal, []byte("goodbye")))
+	flag, payload, err = r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagFinal, flag)
+	assert.Equal(t, []byte("goodbye"), payload)
+
+	// Write a final frame with nil payload (length 0), read it back
+	buf.Reset()
+	require.NoError(t, w.WriteFrame(stream.FlagFinal, nil))
+	flag, payload, err = r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagFinal, flag)
+	assert.Nil(t, payload)
+
+	// Write an error frame, read it back
+	buf.Reset()
+	require.NoError(t, w.WriteFrame(stream.FlagError, []byte("error details")))
+	flag, payload, err = r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagError, flag)
+	assert.Equal(t, []byte("error details"), payload)
+
+	// Write multiple frames sequentially, read them all back in order
+	buf.Reset()
+	require.NoError(t, w.WriteFrame(stream.FlagData, []byte("frame1")))
+	require.NoError(t, w.WriteFrame(stream.FlagData, []byte("frame2")))
+	require.NoError(t, w.WriteFrame(stream.FlagData, []byte("frame3")))
+	require.NoError(t, w.WriteFrame(stream.FlagFinal, nil))
+
+	flag, payload, err = r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagData, flag)
+	assert.Equal(t, []byte("frame1"), payload)
+
+	flag, payload, err = r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagData, flag)
+	assert.Equal(t, []byte("frame2"), payload)
+
+	flag, payload, err = r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagData, flag)
+	assert.Equal(t, []byte("frame3"), payload)
+
+	flag, payload, err = r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagFinal, flag)
+	assert.Nil(t, payload)
+
+	// Large payload (64KB) — verify no corruption
+	buf.Reset()
+	large := make([]byte, 64*1024)
+	for i := range large {
+		large[i] = byte(i % 256)
+	}
+	require.NoError(t, w.WriteFrame(stream.FlagData, large))
+	flag, payload, err = r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagData, flag)
+	assert.Equal(t, large, payload)
+}
+
+func TestReadFrameErrors(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		input   []byte
+		maxSize int
+		wantErr error
+		errMsg  string
+	}{
+		{
+			name:    "ReaderExhaustedAtFrameBoundary",
+			input:   []byte{},
+			maxSize: 0,
+			wantErr: io.EOF,
+		},
+		{
+			name:    "ReaderExhaustedAfterPartialHeader",
+			input:   []byte{0x00, 0x00, 0x00},
+			maxSize: 0,
+			wantErr: io.ErrUnexpectedEOF,
+		},
+		{
+			name: "ReaderExhaustedMidPayload",
+			// Flag=0x00, Length=10 (but only 3 bytes of payload follow)
+			input:   []byte{0x00, 0x00, 0x00, 0x00, 0x0A, 0x01, 0x02, 0x03},
+			maxSize: 0,
+			wantErr: io.ErrUnexpectedEOF,
+		},
+		{
+			name: "PayloadLengthExceedsMax",
+			// Flag=0x00, Length=100
+			input:   []byte{0x00, 0x00, 0x00, 0x00, 0x64},
+			maxSize: 50,
+			errMsg:  "exceeds limit",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := stream.NewReader(bytes.NewReader(test.input), test.maxSize)
+			_, _, err := r.ReadFrame()
+			require.Error(t, err)
+			if test.wantErr != nil {
+				assert.ErrorIs(t, err, test.wantErr)
+			}
+			if test.errMsg != "" {
+				assert.ErrorContains(t, err, test.errMsg)
+			}
+		})
+	}
+
+	// maxPayloadSize of 0 — no limit enforced, large frames succeed
+	t.Run("NoLimitLargeFrameSucceeds", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		large := make([]byte, 128*1024)
+		require.NoError(t, w.WriteFrame(stream.FlagData, large))
+
+		r := stream.NewReader(&buf, 0)
+		flag, payload, err := r.ReadFrame()
+		require.NoError(t, err)
+		assert.Equal(t, stream.FlagData, flag)
+		assert.Len(t, payload, 128*1024)
+	})
+}

--- a/streaming.go
+++ b/streaming.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2023 Derrick J Wippler
+
+Licensed under the MIT License, you may obtain a copy of the License at
+
+https://opensource.org/license/mit/ or in the root of this code repo
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
+	"github.com/duh-rpc/duh.go/v2/stream"
+	json "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// StreamWriter is the server-side interface for writing structured stream frames.
+// It is NOT safe for concurrent use.
+type StreamWriter interface {
+	// Send writes a data frame containing the marshalled message.
+	Send(proto.Message) error
+	// Close writes a final frame and terminates the stream. If the argument is
+	// non-nil, the message is marshalled as the final frame payload. If nil, the
+	// final frame has a zero-length payload. Calling Send or Close after Close
+	// returns an error.
+	Close(proto.Message) error
+	// Context returns the request context, used for cancellation checks in the
+	// handler loop.
+	Context() context.Context
+}
+
+var _ StreamWriter = (*streamWriter)(nil)
+
+type streamWriter struct {
+	w       *stream.Writer
+	flusher http.Flusher
+	marshal func(proto.Message) ([]byte, error)
+	ctx     context.Context
+	closed  bool
+}
+
+func (sw *streamWriter) Send(msg proto.Message) error {
+	if sw.closed {
+		return errors.New("stream is closed")
+	}
+
+	payload, err := sw.marshal(msg)
+	if err != nil {
+		return fmt.Errorf("while marshalling stream message: %w", err)
+	}
+
+	if err := sw.w.WriteFrame(stream.FlagData, payload); err != nil {
+		return err
+	}
+	sw.flusher.Flush()
+	return nil
+}
+
+func (sw *streamWriter) Close(msg proto.Message) error {
+	if sw.closed {
+		return errors.New("stream is closed")
+	}
+	sw.closed = true
+
+	var payload []byte
+	if msg != nil {
+		var err error
+		payload, err = sw.marshal(msg)
+		if err != nil {
+			return fmt.Errorf("while marshalling final stream message: %w", err)
+		}
+	}
+
+	if err := sw.w.WriteFrame(stream.FlagFinal, payload); err != nil {
+		return err
+	}
+	sw.flusher.Flush()
+	return nil
+}
+
+func (sw *streamWriter) Context() context.Context {
+	return sw.ctx
+}
+
+// HandleStream validates the Accept header, asserts http.Flusher, constructs a
+// StreamWriter, calls the handler, and handles error frames on handler failure.
+func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Request, StreamWriter) error) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		ReplyWithCode(w, r, CodeInternalError, nil, "response writer does not support streaming")
+		return
+	}
+
+	accept := TrimSuffix(r.Header.Get("Accept"), ";,")
+	accept = strings.TrimSpace(strings.ToLower(accept))
+
+	var marshalFn func(proto.Message) ([]byte, error)
+	switch accept {
+	case ContentStreamJSON:
+		marshalFn = json.Marshal
+	case ContentStreamProtoBuf:
+		marshalFn = proto.Marshal
+	default:
+		ReplyWithCode(w, r, CodeBadRequest, nil,
+			fmt.Sprintf("Accept header '%s' is not a supported streaming content type; "+
+				"expected '%s' or '%s'", r.Header.Get("Accept"), ContentStreamJSON, ContentStreamProtoBuf))
+		return
+	}
+
+	w.Header().Set("Content-Type", accept)
+
+	sw := &streamWriter{
+		w:       stream.NewWriter(w),
+		flusher: flusher,
+		marshal: marshalFn,
+		ctx:     r.Context(),
+	}
+
+	err := handler(r, sw)
+	if err == nil {
+		return
+	}
+
+	// Handler returned an error. If the stream is already closed (final frame
+	// was sent), silently give up -- the handler had the Send error and already
+	// returned.
+	if sw.closed {
+		return
+	}
+
+	// Construct an error frame from the handler error.
+	reply := buildErrorReply(err)
+	payload, marshalErr := sw.marshal(reply)
+	if marshalErr != nil {
+		// Cannot marshal the error reply; nothing more we can do.
+		return
+	}
+
+	// Write the error frame. If the write fails (client disconnected),
+	// silently give up.
+	if writeErr := sw.w.WriteFrame(stream.FlagError, payload); writeErr != nil {
+		return
+	}
+	sw.flusher.Flush()
+}
+
+// buildErrorReply constructs a v1.Reply from an error. If the error satisfies
+// duh.Error, its Code(), Message(), and Details() are used. Otherwise, the
+// error is wrapped as a CodeInternalError.
+func buildErrorReply(err error) *v1.Reply {
+	var e Error
+	if errors.As(err, &e) {
+		return &v1.Reply{
+			Code:    e.Code(),
+			Message: e.Message(),
+			Details: e.Details(),
+		}
+	}
+	return &v1.Reply{
+		Code:    strconv.Itoa(CodeInternalError),
+		Message: err.Error(),
+	}
+}

--- a/streaming.go
+++ b/streaming.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 
 	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
 	"github.com/duh-rpc/duh.go/v2/stream"
@@ -109,8 +108,7 @@ func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Req
 		return
 	}
 
-	accept := TrimSuffix(r.Header.Get("Accept"), ";,")
-	accept = strings.TrimSpace(strings.ToLower(accept))
+	accept := normalizeMediaType(r.Header.Get("Accept"))
 
 	var marshalFn func(proto.Message) ([]byte, error)
 	switch accept {
@@ -227,7 +225,11 @@ func (sr *streamReader) Recv(msg proto.Message) error {
 
 	switch flag {
 	case stream.FlagData:
-		return sr.unmarshal(payload, msg)
+		if err := sr.unmarshal(payload, msg); err != nil {
+			sr.done = true
+			return err
+		}
+		return nil
 
 	case stream.FlagFinal:
 		if len(payload) > 0 {
@@ -262,10 +264,6 @@ func (sr *streamReader) Recv(msg proto.Message) error {
 
 func (sr *streamReader) Close() error {
 	sr.cancel()
-	if sr.done {
-		_ = sr.resp.Body.Close()
-		return nil
-	}
 	sr.done = true
 	return sr.resp.Body.Close()
 }

--- a/streaming.go
+++ b/streaming.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -174,4 +175,95 @@ func buildErrorReply(err error) *v1.Reply {
 		Code:    strconv.Itoa(CodeInternalError),
 		Message: err.Error(),
 	}
+}
+
+// StreamReader is the client-side interface for reading structured stream frames.
+// It is NOT safe for concurrent use.
+type StreamReader interface {
+	// Recv reads the next frame from the stream and unmarshals the payload into
+	// the provided message. Returns io.EOF when the stream is complete.
+	Recv(proto.Message) error
+	// Close aborts the in-flight HTTP response and releases resources.
+	// Safe to call multiple times.
+	Close() error
+}
+
+var _ StreamReader = (*streamReader)(nil)
+
+type streamReader struct {
+	r          *stream.Reader
+	resp       *http.Response
+	unmarshal  func([]byte, proto.Message) error
+	cancel     context.CancelFunc
+	done       bool
+	hasPending bool
+}
+
+func (sr *streamReader) Recv(msg proto.Message) error {
+	// If the stream is already done and there is no pending final payload, return EOF.
+	if sr.done && !sr.hasPending {
+		return io.EOF
+	}
+
+	// If a previous call read a final frame with payload, the payload was already
+	// unmarshalled. This call returns EOF to signal stream completion.
+	if sr.hasPending {
+		sr.hasPending = false
+		sr.done = true
+		return io.EOF
+	}
+
+	flag, payload, err := sr.r.ReadFrame()
+	if err != nil {
+		if err == io.EOF {
+			// Stream ended without a final or error frame -- infrastructure error per spec.
+			sr.done = true
+			return io.ErrUnexpectedEOF
+		}
+		sr.done = true
+		return err
+	}
+
+	switch flag {
+	case stream.FlagData:
+		return sr.unmarshal(payload, msg)
+
+	case stream.FlagFinal:
+		if len(payload) > 0 {
+			if err := sr.unmarshal(payload, msg); err != nil {
+				sr.done = true
+				return err
+			}
+			sr.hasPending = true
+			return nil
+		}
+		sr.done = true
+		return io.EOF
+
+	case stream.FlagError:
+		sr.done = true
+		var reply v1.Reply
+		if err := sr.unmarshal(payload, &reply); err != nil {
+			return fmt.Errorf("while unmarshalling error frame: %w", err)
+		}
+		return &ClientError{
+			code:     reply.Code,
+			httpCode: sr.resp.StatusCode,
+			msg:      reply.Message,
+			details:  reply.Details,
+		}
+
+	default:
+		sr.done = true
+		return fmt.Errorf("unknown frame flag: 0x%x", flag)
+	}
+}
+
+func (sr *streamReader) Close() error {
+	if sr.done {
+		return nil
+	}
+	sr.done = true
+	sr.cancel()
+	return sr.resp.Body.Close()
 }

--- a/streaming.go
+++ b/streaming.go
@@ -54,9 +54,12 @@ type streamWriter struct {
 	closed  bool
 }
 
+// ErrStreamClosed is returned when Send or Close is called on a closed StreamWriter.
+var ErrStreamClosed = errors.New("stream is closed")
+
 func (sw *streamWriter) Send(msg proto.Message) error {
 	if sw.closed {
-		return errors.New("stream is closed")
+		return ErrStreamClosed
 	}
 
 	payload, err := sw.marshal(msg)
@@ -73,7 +76,7 @@ func (sw *streamWriter) Send(msg proto.Message) error {
 
 func (sw *streamWriter) Close(msg proto.Message) error {
 	if sw.closed {
-		return errors.New("stream is closed")
+		return ErrStreamClosed
 	}
 	sw.closed = true
 
@@ -143,7 +146,6 @@ func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Req
 		return
 	}
 
-	// Construct an error frame from the handler error.
 	reply := buildErrorReply(err)
 	payload, marshalErr := sw.marshal(reply)
 	if marshalErr != nil {
@@ -200,7 +202,6 @@ type streamReader struct {
 }
 
 func (sr *streamReader) Recv(msg proto.Message) error {
-	// If the stream is already done and there is no pending final payload, return EOF.
 	if sr.done && !sr.hasPending {
 		return io.EOF
 	}
@@ -260,10 +261,11 @@ func (sr *streamReader) Recv(msg proto.Message) error {
 }
 
 func (sr *streamReader) Close() error {
+	sr.cancel()
 	if sr.done {
+		_ = sr.resp.Body.Close()
 		return nil
 	}
 	sr.done = true
-	sr.cancel()
 	return sr.resp.Body.Close()
 }


### PR DESCRIPTION
### Purpose

Add streaming support to duh.go, implementing both structured streams (`application/duh-stream+json`, `application/duh-stream+protobuf`) and unstructured streams (`application/octet-stream`). This enables server-to-client streaming over HTTP with length-prefixed binary framing, content negotiation, error frames, and automatic flushing.

### Implementation

- **`stream` sub-package** (`stream/stream.go`): Wire format encoding/decoding with `Writer` and `Reader` types operating on `io.Writer`/`io.Reader`. Defines `FlagData`, `FlagFinal`, `FlagError` frame type constants. Zero external dependencies (stdlib only). `Reader` supports max payload size limits.

- **Server-side streaming** (`streaming.go`, `service.go`): `StreamWriter` interface with `Send`, `Close`, `Context` methods. `HandleStream` function validates the `Accept` header, asserts `http.Flusher`, constructs the stream writer, and handles error frames if the handler returns an error. Added `ContentStreamJSON` and `ContentStreamProtoBuf` constants.

- **Client-side streaming** (`client.go`, `streaming.go`): `StreamReader` interface with `Recv` and `Close` methods handling data/final/error frames. `Client.DoStream` for structured stream responses with cancellable child context. `Client.DoBytes` for unstructured octet-stream responses. `MaxFramePayload` field on `Client` with 4MB default. Shared `handleErrorResponse` helper for non-200 error classification.

- **Demo and test fixtures** (`demo/`, `internal/test/`, `functional_test.go`): Streaming `ListEvents` endpoint and `DownloadBytes` endpoint in demo. `TestStream` fixture in `internal/test/` with configurable error injection and close-with-payload. Eight functional tests covering happy path, error frames, close-with-payload, bad accept header, send-after-close, server disconnect, context cancellation, and DoBytes.