### PR TITLE
Simplify v2 code: deduplicate, fix bugs, add regression tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,22 +122,15 @@ func (c *Client) Do(req *http.Request, out proto.Message) error {
 		}
 	}
 
-	switch normalizeMediaType(resp.Header.Get("Content-Type")) {
-	case ContentTypeJSON:
-		if err := json.Unmarshal(body.Bytes(), out); err != nil {
-			return NewClientError(
-				"", fmt.Errorf("while parsing response body '%s': %w", body.Bytes(), err), nil)
-		}
-		return nil
-	case ContentTypeProtoBuf:
-		if err := proto.Unmarshal(body.Bytes(), out); err != nil {
-			return NewClientError(
-				"", fmt.Errorf("while parsing response body '%s': %w", body.Bytes(), err), nil)
-		}
-		return nil
-	default:
+	unmarshalFn, ok := unmarshalForMediaType(resp.Header.Get("Content-Type"))
+	if !ok {
 		return NewInfraError(req, resp, body.Bytes())
 	}
+	if err := unmarshalFn(body.Bytes(), out); err != nil {
+		return NewClientError(
+			"", fmt.Errorf("while parsing response body '%s': %w", body.Bytes(), err), nil)
+	}
+	return nil
 }
 
 // NewReplyError returns an error that originates from the service implementation, and does not originate from
@@ -147,7 +140,7 @@ func (c *Client) Do(req *http.Request, out proto.Message) error {
 // back to the caller as an error.
 func NewReplyError(req *http.Request, resp *http.Response, reply *v1.Reply) error {
 	details := map[string]string{
-		DetailsHttpCode:   fmt.Sprintf("%d", resp.StatusCode),
+		DetailsHttpCode:   strconv.Itoa(resp.StatusCode),
 		DetailsCodeText:   CodeText(resp.StatusCode),
 		DetailsHttpUrl:    req.URL.String(),
 		DetailsHttpMethod: req.Method,
@@ -177,7 +170,7 @@ func NewReplyError(req *http.Request, resp *http.Response, reply *v1.Reply) erro
 func NewInfraError(req *http.Request, resp *http.Response, body []byte) error {
 	return &ClientError{
 		details: map[string]string{
-			DetailsHttpCode:   fmt.Sprintf("%d", resp.StatusCode),
+			DetailsHttpCode:   strconv.Itoa(resp.StatusCode),
 			DetailsHttpBody:   string(body),
 			DetailsHttpUrl:    req.URL.String(),
 			DetailsHttpStatus: resp.Status,
@@ -282,6 +275,19 @@ func (c *Client) DoBytes(ctx context.Context, req *http.Request) (io.ReadCloser,
 	return resp.Body, nil
 }
 
+// unmarshalForMediaType returns the appropriate unmarshal function for the given
+// Content-Type header value. Returns false if the media type is not recognized.
+func unmarshalForMediaType(contentType string) (func([]byte, proto.Message) error, bool) {
+	switch normalizeMediaType(contentType) {
+	case ContentTypeJSON:
+		return json.Unmarshal, true
+	case ContentTypeProtoBuf:
+		return proto.Unmarshal, true
+	default:
+		return nil, false
+	}
+}
+
 // handleErrorResponse reads the response body and classifies the error based
 // on the content type and body contents. It closes the response body.
 func handleErrorResponse(req *http.Request, resp *http.Response) error {
@@ -301,20 +307,13 @@ func handleErrorResponse(req *http.Request, resp *http.Response) error {
 		}
 	}
 
-	switch normalizeMediaType(resp.Header.Get("Content-Type")) {
-	case ContentTypeJSON:
-		var reply v1.Reply
-		if err := json.Unmarshal(body.Bytes(), &reply); err != nil {
-			return NewInfraError(req, resp, body.Bytes())
-		}
-		return NewReplyError(req, resp, &reply)
-	case ContentTypeProtoBuf:
-		var reply v1.Reply
-		if err := proto.Unmarshal(body.Bytes(), &reply); err != nil {
-			return NewInfraError(req, resp, body.Bytes())
-		}
-		return NewReplyError(req, resp, &reply)
-	default:
+	unmarshalFn, ok := unmarshalForMediaType(resp.Header.Get("Content-Type"))
+	if !ok {
 		return NewInfraError(req, resp, body.Bytes())
 	}
+	var reply v1.Reply
+	if err := unmarshalFn(body.Bytes(), &reply); err != nil {
+		return NewInfraError(req, resp, body.Bytes())
+	}
+	return NewReplyError(req, resp, &reply)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -207,7 +207,36 @@ func TestErrorInterface(t *testing.T) {
 	require.True(t, errors.As(err, &e))
 	assert.Equal(t, "CARD_DECLINED", e.Code())
 	assert.Equal(t, duh.CodeRequestFailed, e.HTTPCode())
-	assert.Equal(t, "Request Failed:card was declined", e.Error())
+	assert.Equal(t, "Request Failed: card was declined", e.Error())
+}
+
+func TestServiceErrorNilErr(t *testing.T) {
+	// NewServiceErrorWithCode with both msg="" and err=nil must not panic
+	err := duh.NewServiceErrorWithCode(duh.CodeBadRequest, "400", "", nil, nil)
+	var e duh.Error
+	require.True(t, errors.As(err, &e))
+
+	assert.Equal(t, "", e.Message())
+	assert.Equal(t, "Bad Request", e.Error())
+	assert.Equal(t, "400", e.Code())
+	assert.Equal(t, duh.CodeBadRequest, e.HTTPCode())
+}
+
+func TestClientErrorProtoMessageNoMutation(t *testing.T) {
+	// ProtoMessage() must not mutate the receiver's Message() return value
+	err := duh.NewClientError("some error: %w", fmt.Errorf("inner"), nil)
+
+	var ce *duh.ClientError
+	require.True(t, errors.As(err, &ce))
+
+	msgBefore := ce.Message()
+
+	// Call ProtoMessage -- this previously mutated ce.msg
+	reply := ce.ProtoMessage()
+	require.NotNil(t, reply)
+
+	msgAfter := ce.Message()
+	assert.Equal(t, msgBefore, msgAfter)
 }
 
 func TestDoStreamErrors(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -145,11 +145,17 @@ func (e *serviceError) HTTPCode() int {
 }
 
 func (e *serviceError) Message() string {
-	return e.err.Error()
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return ""
 }
 
 func (e *serviceError) Error() string {
-	return CodeText(e.httpCode) + ":" + e.err.Error()
+	if e.err != nil {
+		return CodeText(e.httpCode) + ": " + e.err.Error()
+	}
+	return CodeText(e.httpCode)
 }
 
 func (e *serviceError) Details() map[string]string {
@@ -166,13 +172,14 @@ type ClientError struct {
 }
 
 func (e *ClientError) ProtoMessage() proto.Message {
-	if e.err != nil && e.msg == "" {
-		e.msg = e.err.Error()
+	msg := e.msg
+	if e.err != nil && msg == "" {
+		msg = e.err.Error()
 	}
 	return &v1.Reply{
 		Code:    e.code,
 		Details: e.details,
-		Message: e.msg,
+		Message: msg,
 	}
 }
 
@@ -193,12 +200,10 @@ func (e *ClientError) Message() string {
 }
 
 func (e *ClientError) Error() string {
-	// If e.err is set, it means this error is from the client
 	if e.err != nil {
 		return CodeText(e.httpCode) + ": " + e.err.Error()
 	}
 
-	// This means the reply is not from the service, but from the infrastructure.
 	if e.isInfraError {
 		return fmt.Sprintf("%s %s returned infrastructure error %d with body: %s",
 			e.details[DetailsHttpMethod],
@@ -207,7 +212,7 @@ func (e *ClientError) Error() string {
 			e.msg,
 		)
 	}
-	// Error is from the service
+
 	return fmt.Sprintf("%s %s returned '%s' with message: %s",
 		e.details[DetailsHttpMethod],
 		e.details[DetailsHttpUrl],

--- a/policies.go
+++ b/policies.go
@@ -15,6 +15,8 @@ limitations under the License.
 package duh
 
 import (
+	"net/http"
+
 	"github.com/duh-rpc/duh.go/v2/retry"
 )
 
@@ -27,7 +29,7 @@ var RetryableCodes = []int{CodeTooManyRequests, CodeRetryRequest, CodeInternalEr
 // A service 404 (with Reply body) means "resource not found" and is NOT in
 // RetryableCodes, so it won't be retried. The OnCodes/OnInfraCodes split makes
 // this distinction safe.
-var RetryableInfraCodes = []int{CodeNotFound, 502, 503, 504}
+var RetryableInfraCodes = []int{CodeNotFound, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout}
 
 // OnRetryable retries indefinitely on known retryable service codes and
 // infrastructure errors. Cancel via context.

--- a/reader.go
+++ b/reader.go
@@ -18,7 +18,7 @@ const (
 	MegaByte = Kilobyte * 1000
 	Mebibyte = Kibibyte * 1024
 	Gibibyte = Mebibyte * 1024
-	Gigabyte = MegaByte * 1024
+	Gigabyte = MegaByte * 1000
 )
 
 // NewLimitReader returns a ReaderCloser that returns ErrDataLimitExceeded after n bytes have been read.

--- a/reader_test.go
+++ b/reader_test.go
@@ -11,6 +11,15 @@ import (
 	"testing"
 )
 
+func TestSIConstants(t *testing.T) {
+	assert.Equal(t, int64(1000), int64(duh.Kilobyte))
+	assert.Equal(t, int64(1024), int64(duh.Kibibyte))
+	assert.Equal(t, int64(1_000_000), int64(duh.MegaByte))
+	assert.Equal(t, int64(1_048_576), int64(duh.Mebibyte))
+	assert.Equal(t, int64(1_000_000_000), int64(duh.Gigabyte))
+	assert.Equal(t, int64(1_073_741_824), int64(duh.Gibibyte))
+}
+
 func TestNewReader(t *testing.T) {
 	// Can read up to the requested limit
 	r := duh.NewLimitReader(io.NopCloser(strings.NewReader("twenty regular bytes")), 20)

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -61,8 +61,12 @@ type BackOff struct {
 
 func (b BackOff) Next(attempts int) time.Duration {
 	d := time.Duration(float64(b.Min) * math.Pow(b.Factor, float64(attempts)))
-	if b.Rand != nil {
-		d = time.Duration(b.Rand.Float64() * b.Jitter * float64(d))
+	if b.Jitter > 0 {
+		r := rand.Float64()
+		if b.Rand != nil {
+			r = b.Rand.Float64()
+		}
+		d = time.Duration(r * b.Jitter * float64(d))
 	}
 	if d > b.Max {
 		return b.Max
@@ -74,7 +78,6 @@ func (b BackOff) Next(attempts int) time.Duration {
 }
 
 var DefaultBackOff = BackOff{
-	Rand:   rand.New(rand.NewSource(time.Now().UnixNano())),
 	Min:    500 * time.Millisecond,
 	Max:    5 * time.Second,
 	Jitter: 0.2,
@@ -136,18 +139,15 @@ func shouldRetry(err error, policy Policy) bool {
 		panic("err cannot be nil")
 	}
 
-	// If no codes are specified, retry any error
 	if policy.OnCodes == nil && policy.OnInfraCodes == nil {
 		return true
 	}
 
-	// Extract the HTTP status code from the error
 	var hc httpCoder
 	if !errors.As(err, &hc) {
 		return false
 	}
 
-	// Check if this is an infrastructure error
 	var ic infraChecker
 	if errors.As(err, &ic) && ic.IsInfraError() {
 		if policy.OnInfraCodes != nil {
@@ -156,7 +156,6 @@ func shouldRetry(err error, policy Policy) bool {
 		return false
 	}
 
-	// Service error (or non-ClientError with HTTPCode)
 	if policy.OnCodes != nil {
 		return slices.Contains(policy.OnCodes, hc.HTTPCode())
 	}
@@ -176,7 +175,6 @@ func rateLimitDuration(err error) time.Duration {
 		return 0
 	}
 
-	// Check for ratelimit-reset or http.retry-after
 	for _, key := range []string{detailRateLimitReset, detailRetryAfter} {
 		if v, ok := details[key]; ok {
 			seconds, parseErr := strconv.ParseFloat(v, 64)
@@ -205,12 +203,17 @@ func On(ctx context.Context, p Policy, operation func(context.Context, int) erro
 			}
 
 			if shouldRetry(err, p) {
-				// Use rate-limit duration if available, otherwise use backoff
 				sleepDur := rateLimitDuration(err)
 				if sleepDur == 0 {
 					sleepDur = p.Interval.Next(attempt)
 				}
-				time.Sleep(sleepDur)
+				timer := time.NewTimer(sleepDur)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return ctx.Err()
+				case <-timer.C:
+				}
 				attempt++
 			} else {
 				return err

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -359,6 +359,52 @@ func TestRetry(t *testing.T) {
 	})
 }
 
+func TestBackOffConcurrentSafety(t *testing.T) {
+	// DefaultBackOff must be safe for concurrent use from multiple goroutines.
+	// Previously, DefaultBackOff contained a shared *rand.Rand which is not goroutine-safe.
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				d := retry.DefaultBackOff.Next(j % 5)
+				_ = d
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestRetrySleepContextCancel(t *testing.T) {
+	// Cancelling the context during a retry sleep must return promptly,
+	// not after the full sleep duration elapses.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	policy := retry.Policy{
+		Interval: retry.Sleep(10 * time.Second),
+		Attempts: 0,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- retry.On(ctx, policy, func(ctx context.Context, attempt int) error {
+			return errors.New("always fail")
+		})
+	}()
+
+	// Give the retry loop time to enter its sleep
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	start := time.Now()
+	err := <-done
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, time.Second)
+}
+
 // makeInfraError creates a *duh.ClientError with IsInfraError() == true by using duh.NewInfraError
 // with a test HTTP response.
 func makeInfraError(t *testing.T, statusCode int) error {

--- a/service.go
+++ b/service.go
@@ -107,35 +107,32 @@ func ReplyError(w http.ResponseWriter, r *http.Request, err error) {
 func Reply(w http.ResponseWriter, r *http.Request, code int, resp proto.Message) {
 	mimeType := normalizeMediaType(r.Header.Get("Accept"))
 
+	var marshalFn func(proto.Message) ([]byte, error)
+	var contentType string
 	switch mimeType {
 	case "", "*/*", "application/*", ContentTypeJSON:
-		b, err := json.Marshal(resp)
-		if err != nil {
-			// TODO: This should be logged and not returned to the client, we need to define a logger
-			ReplyWithCode(w, r, CodeInternalError, nil, err.Error())
-			return
-		}
-		w.Header().Set("Content-Type", ContentTypeJSON)
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.WriteHeader(code)
-		_, _ = w.Write(b)
+		marshalFn = json.Marshal
+		contentType = ContentTypeJSON
 	case ContentTypeProtoBuf:
-		b, err := proto.Marshal(resp)
-		if err != nil {
-			// TODO: This should be logged and not returned to the client, we need to define a logger
-			ReplyWithCode(w, r, CodeInternalError, nil, err.Error())
-			return
-		}
-		w.Header().Set("Content-Type", ContentTypeProtoBuf)
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.WriteHeader(code)
-		_, _ = w.Write(b)
+		marshalFn = proto.Marshal
+		contentType = ContentTypeProtoBuf
 	default:
 		r.Header.Set("Accept", ContentTypeJSON)
 		ReplyWithCode(w, r, CodeClientContentError, nil, fmt.Sprintf("Accept header '%s' is invalid format "+
 			"or unrecognized content type, only [%s] are supported by this method",
 			mimeType, strings.Join(SupportedMimeTypes, ",")))
+		return
 	}
+
+	b, err := marshalFn(resp)
+	if err != nil {
+		ReplyWithCode(w, r, CodeInternalError, nil, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	_, _ = w.Write(b)
 }
 
 // TrimSuffix trims everything after the first separator is found

--- a/streaming.go
+++ b/streaming.go
@@ -133,43 +133,27 @@ func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Req
 	}
 
 	err := handler(r, sw)
-	if err == nil {
-		return
-	}
-
-	// Handler returned an error. If the stream is already closed (final frame
-	// was sent), silently give up -- the handler had the Send error and already
-	// returned.
-	if sw.closed {
+	if err == nil || sw.closed {
 		return
 	}
 
 	reply := buildErrorReply(err)
 	payload, marshalErr := sw.marshal(reply)
 	if marshalErr != nil {
-		// Cannot marshal the error reply; nothing more we can do.
 		return
 	}
 
-	// Write the error frame. If the write fails (client disconnected),
-	// silently give up.
 	if writeErr := sw.w.WriteFrame(stream.FlagError, payload); writeErr != nil {
 		return
 	}
 	sw.flusher.Flush()
 }
 
-// buildErrorReply constructs a v1.Reply from an error. If the error satisfies
-// duh.Error, its Code(), Message(), and Details() are used. Otherwise, the
-// error is wrapped as a CodeInternalError.
+// buildErrorReply constructs a v1.Reply from an error.
 func buildErrorReply(err error) *v1.Reply {
 	var e Error
 	if errors.As(err, &e) {
-		return &v1.Reply{
-			Code:    e.Code(),
-			Message: e.Message(),
-			Details: e.Details(),
-		}
+		return e.ProtoMessage().(*v1.Reply)
 	}
 	return &v1.Reply{
 		Code:    strconv.Itoa(CodeInternalError),


### PR DESCRIPTION
### Purpose

Simplify and clean up the v2 codebase by eliminating code duplication across JSON/ProtoBuf content-type branches, fixing several correctness bugs discovered during review, and adding regression tests for each fix.

### Implementation

- Unified duplicated JSON/ProtoBuf marshal/unmarshal branches in `client.go` (`Do`, `handleErrorResponse`) and `service.go` (`Reply`) by selecting the function upfront and sharing a single code path
- Fixed `serviceError.Message()` and `Error()` nil-pointer panic when constructed with both empty `msg` and nil `err`
- Fixed `ClientError.ProtoMessage()` mutating the receiver's `msg` field (potential data race under concurrent use) — now uses a local variable
- Fixed `Gigabyte` SI constant using binary multiplier (`*1024`) instead of decimal (`*1000`)
- Fixed `DefaultBackOff.Rand` data race — removed shared non-goroutine-safe `*rand.Rand`; `BackOff.Next()` now uses the goroutine-safe global `rand.Float64()` by default
- Made `retry.On` sleep context-cancelable via `time.NewTimer` + `select` instead of `time.Sleep`
- Fixed inconsistent colon formatting in `serviceError.Error()` (`:` → `: ` to match `ClientError.Error()`)
- Replaced `fmt.Sprintf("%d")` with `strconv.Itoa()` and raw `502/503/504` literals with `http.Status*` constants
- Simplified `buildErrorReply` to delegate to `Error.ProtoMessage()` instead of manually reconstructing the Reply
- Removed comments that restated what the code does
- Added regression tests: `TestServiceErrorNilErr`, `TestClientErrorProtoMessageNoMutation`, `TestSIConstants`, `TestBackOffConcurrentSafety`, `TestRetrySleepContextCancel`