### PR TITLE
Spec: make all Reply structure fields optional

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,9 +1,9 @@
-# The DUH Spec V3
+# The DUH Spec V2
 Here we are presenting a general protocol approach to implementing RPC over HTTP. The benefit of using tried-and-true nature of HTTP for RPC allows designers to leverage the many tools and frameworks readily available to design, document, and implement high-performance HTTP APIs without overly complex client or deployment strategies.
 
 When using plain HTTP, a `404 Not Found` could mean a load balancer, API gateway, or proxy couldn't find your service at all — or it could mean your service couldn't find the requested resource. To the client, both look identical. DUH-RPC solves this by using the **Reply structure** as the definitive signal: any response that includes a well-formed Reply body originated from the service; any response that doesn't is treated as infrastructure. This distinction drives how clients interpret errors and whether they should retry.
 
-> The optional `Server: DUH-RPC/1.0` header can help identify service responses when the body isn't available (e.g., in logs), but it may be scrubbed by proxies and should not be relied upon programmatically.
+> The optional `Server: DUH-RPC/2.0` header can help identify service responses when the body isn't available (e.g., in logs), but it may be scrubbed by proxies and should not be relied upon programmatically.
 
 DUH method calls take the form `/v1/problem-domain/subject.method`
 
@@ -81,7 +81,7 @@ Content-Type: <MIME_type>/<MIME_subtype>
 
 The mime types supported can change depending on the method. This allows service implementations to migrate from older  mime types or to support mime types of a specific use case.
 
-If the server can accommodate none of the mime types, the server WILL return code `400` and a standard reply structure with the message  
+If the server can accommodate none of the mime types, the server WILL return HTTP status code `400` and a standard reply structure with the message  
 ```
 Accept header 'application/bson' is invalid format or unrecognized content type, only 
 [application/json, application/protobuf] are supported by this method
@@ -97,12 +97,14 @@ Standard replies from the service SHOULD follow a common structure. This provide
 #### Reply Structure
 The reply structure has the following fields.
 
-* **Code** (Required) — An application-level signal controlled by the implementor. It MAY be a numeric string
+* **Code** (Optional) — An application-level signal controlled by the implementor. It MAY be a numeric string
   (e.g. `"400"`, `"453"`) or a semantic string meaningful to the application (e.g. `"CARD_DECLINED"`,
   `"RATE_LIMITED"`). The HTTP status code is the authoritative signal for retry and routing decisions — client
   implementations MUST base retry logic on the HTTP status code, not the `code` field.
 * **Message** (Optional) — A human readable message.
-* **Details** — (Optional) A map of string key/value pairs providing additional context about this error, which could include a link to documentation explaining the error or additional machine-readable codes.
+* **Details** (Optional) — A map of string key/value pairs providing additional context about this error, which could include a link to documentation explaining the error or additional machine-readable codes.
+
+All fields are optional. A Reply MAY contain only `code`, only `message`, only `details`, or any combination. The presence of a well-formed Reply structure (even an empty one) is what distinguishes a service response from an infrastructure response — see [Infrastructure Errors](#infrastructure-errors).
 
 > Although the **Reply** structure is typically used for error replies, it CAN be used in normal `200` responses when there is a desire to avoid adding a new `<MethodCall>Response` type for simple method call which has no detailed responses.
 
@@ -215,7 +217,7 @@ The Client SHOULD handle responses that do not include the **Reply** structure a
 For example, if the client implementation receives an HTTP status code of `404` and a status message of `Not Found` from the request, the client SHOULD assume the error is from the infrastructure and inform the caller in a way that is suitable for the language used.
 
 ### Infrastructure Errors
-An infrastructure error is any HTTP response code that is NOT 200 and DOES NOT include a `Reply` structure in the body. If the client receives a response code and it DOES NOT include a `Reply` structure in the expected serialization format, then the client MUST consider the response as an infrastructure error and handling it accordingly.
+An infrastructure error is any HTTP response status code that is NOT 200 and DOES NOT include a `Reply` structure in the body. If the client receives a response code and it DOES NOT include a `Reply` structure in the expected serialization format, then the client MUST consider the response as an infrastructure error and handling it accordingly.
 
 Typically, infrastructure errors are 5XX class errors, but could also be 404 Not Found errors, or consist of 
 non-standard or future HTTP status codes. As such it is recommended that client implementations do not attempt to handle all possible HTTP codes, but instead consider any non 200 responses without a `Reply` an infrastructure class
@@ -224,7 +226,7 @@ error.
 A `404` is the most common example of this ambiguity. A service `404` — one that includes a Reply body — means the requested resource does not exist and should not be retried. An infrastructure `404` — one without a Reply body — means the request never reached the service and SHOULD be retried.
 
 ##### Service Identifiers
-In addition, the server CAN include the `Server: DUH-RPC/1.0 (Golang)` header according to [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.server) to help identify the source of the HTTP Status. (It is possible that proxy or API gateways will scrub or overwrite this header as a security measure, which will make identification of the source more difficult) 
+In addition, the server CAN include the `Server: DUH-RPC/2.0 (Golang)` header according to [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#field.server) to help identify the source of the HTTP Status. (It is possible that proxy or API gateways will scrub or overwrite this header as a security measure, which will make identification of the source more difficult) 
 
 ## Retry Semantics
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -496,6 +496,70 @@ func TestRetryOnInfraError(t *testing.T) {
 	assert.Equal(t, 3, attempts)
 }
 
+func TestSayHelloErrors(t *testing.T) {
+	server := httptest.NewServer(&demo.Handler{Service: demo.NewService()})
+	defer server.Close()
+
+	c := demo.NewClient(demo.ClientConfig{Endpoint: server.URL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	for _, tt := range []struct {
+		name    string
+		req     string
+		wantMsg string
+	}{
+		{
+			name:    "empty name",
+			req:     "",
+			wantMsg: "'name' is required",
+		},
+		{
+			name:    "name not capitalized",
+			req:     "admiral thrawn",
+			wantMsg: "'name' must be capitalized",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.SayHello(ctx, &demo.SayHelloRequest{Name: tt.req}, &demo.SayHelloResponse{})
+			require.Error(t, err)
+
+			var duhErr *duh.ClientError
+			require.True(t, errors.As(err, &duhErr))
+			assert.Equal(t, duh.CodeBadRequest, duhErr.HTTPCode())
+			assert.Contains(t, duhErr.Message(), tt.wantMsg)
+		})
+	}
+}
+
+func TestListEventsStream(t *testing.T) {
+	server := httptest.NewServer(&demo.Handler{Service: demo.NewService()})
+	defer server.Close()
+
+	c := demo.NewClient(demo.ClientConfig{Endpoint: server.URL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	sr, err := c.ListEvents(ctx, &demo.ListEventsRequest{Count: 3})
+	require.NoError(t, err)
+	require.NotNil(t, sr)
+
+	for i := 0; i < 3; i++ {
+		var event demo.Event
+		require.NoError(t, sr.Recv(&event))
+		assert.Equal(t, int64(i), event.Sequence)
+		assert.Equal(t, fmt.Sprintf("event-%d", i), event.Message)
+	}
+
+	// Next Recv returns EOF after all events are consumed
+	var event demo.Event
+	assert.Equal(t, io.EOF, sr.Recv(&event))
+
+	require.NoError(t, sr.Close())
+}
+
 // TODO: Update the benchmark tests
 
 // TODO: DUH-RPC Validation Test for any endpoint

--- a/functional_test.go
+++ b/functional_test.go
@@ -22,12 +22,15 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/duh-rpc/duh.go/v2"
 	"github.com/duh-rpc/duh.go/v2/demo"
 	"github.com/duh-rpc/duh.go/v2/internal/test"
+	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
+	"github.com/duh-rpc/duh.go/v2/retry"
 	"github.com/duh-rpc/duh.go/v2/stream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -412,6 +415,85 @@ func TestDoBytesHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "hello, bytes", string(data))
 	require.NoError(t, rc.Close())
+}
+
+// fastRetryablePolicy mirrors duh.OnRetryable but with a 1ms sleep for test speed.
+var fastRetryablePolicy = retry.Policy{
+	Interval:     retry.Sleep(time.Millisecond),
+	OnCodes:      duh.RetryableCodes,
+	OnInfraCodes: duh.RetryableInfraCodes,
+	Attempts:     0,
+}
+
+func TestRetryOnRetryableServiceError(t *testing.T) {
+	var count atomic.Int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := count.Add(1)
+		if n <= 2 {
+			duh.ReplyWithCode(w, r, duh.CodeTooManyRequests, nil, "rate limited")
+			return
+		}
+		duh.Reply(w, r, duh.CodeOK, &v1.Reply{})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := duh.Client{Client: &http.Client{}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	attempts := 0
+	err := retry.On(ctx, fastRetryablePolicy, func(ctx context.Context, attempt int) error {
+		attempts++
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test", nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", duh.ContentTypeJSON)
+		return c.Do(req, &v1.Reply{})
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, attempts)
+}
+
+func TestRetryOnInfraError(t *testing.T) {
+	var count atomic.Int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := count.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("bad gateway"))
+			return
+		}
+		duh.Reply(w, r, duh.CodeOK, &v1.Reply{})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := duh.Client{Client: &http.Client{}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	attempts := 0
+	err := retry.On(ctx, fastRetryablePolicy, func(ctx context.Context, attempt int) error {
+		attempts++
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test", nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", duh.ContentTypeJSON)
+		return c.Do(req, &v1.Reply{})
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, attempts)
 }
 
 // TODO: Update the benchmark tests

--- a/reader_test.go
+++ b/reader_test.go
@@ -11,13 +11,15 @@ import (
 	"testing"
 )
 
-func TestSIConstants(t *testing.T) {
-	assert.Equal(t, int64(1000), int64(duh.Kilobyte))
-	assert.Equal(t, int64(1024), int64(duh.Kibibyte))
-	assert.Equal(t, int64(1_000_000), int64(duh.MegaByte))
-	assert.Equal(t, int64(1_048_576), int64(duh.Mebibyte))
-	assert.Equal(t, int64(1_000_000_000), int64(duh.Gigabyte))
-	assert.Equal(t, int64(1_073_741_824), int64(duh.Gibibyte))
+// eternalReader is a non-allocating io.Reader that fills any buffer with zero bytes.
+// It is used to test large byte-limit boundaries without allocating gigabytes on the heap.
+type eternalReader struct{}
+
+func (eternalReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
 }
 
 func TestNewReader(t *testing.T) {
@@ -37,7 +39,9 @@ func TestNewReader(t *testing.T) {
 	var d duh.Error
 	assert.True(t, errors.As(err, &d))
 
-	// Returns the correct SI abbreviations
+	// Verify SI vs binary byte constants produce the correct unit labels in error messages.
+	// Kilobyte = 1000 (kB), Kibibyte = 1024 (KiB), MegaByte = 1_000_000 (MB), Mebibyte = 1_048_576 (MiB),
+	// Gigabyte = 1_000_000_000 (GB), Gibibyte = 1_073_741_824 (GiB).
 	r = duh.NewLimitReader(io.NopCloser(bytes.NewReader(make([]byte, duh.Kilobyte*2))), duh.Kilobyte)
 	_, err = io.ReadAll(r)
 	require.Error(t, err)
@@ -57,4 +61,14 @@ func TestNewReader(t *testing.T) {
 	_, err = io.ReadAll(r)
 	require.Error(t, err)
 	assert.Equal(t, "exceeds 1.0MiB limit", err.Error())
+
+	r = duh.NewLimitReader(io.NopCloser(eternalReader{}), duh.Gigabyte)
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Equal(t, "exceeds 1.0GB limit", err.Error())
+
+	r = duh.NewLimitReader(io.NopCloser(eternalReader{}), duh.Gibibyte)
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Equal(t, "exceeds 1.0GiB limit", err.Error())
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 	"testing"
@@ -85,7 +86,6 @@ func TestSetupTLS(t *testing.T) {
 			require.NoError(t, err)
 
 			srv := http.Server{
-				Addr: "localhost:9685",
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					_, _ = fmt.Fprintln(w, "Hello, client")
 				}),
@@ -93,11 +93,14 @@ func TestSetupTLS(t *testing.T) {
 			}
 			defer func() { _ = srv.Close() }()
 
+			listener, err := net.Listen("tcp", "localhost:9685")
+			require.NoError(t, err)
+
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err = srv.ListenAndServeTLS("", "")
+				err := srv.ServeTLS(listener, "", "")
 				if err != nil && !errors.Is(err, http.ErrServerClosed) {
 					t.Logf("server listen error: %v", err)
 				}
@@ -131,7 +134,6 @@ func TestSetupTLSSkipVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	srv := http.Server{
-		Addr: "localhost:9685",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = fmt.Fprintln(w, "Hello, client")
 		}),
@@ -139,11 +141,14 @@ func TestSetupTLSSkipVerify(t *testing.T) {
 	}
 	defer func() { _ = srv.Close() }()
 
+	listener, err := net.Listen("tcp", "localhost:9685")
+	require.NoError(t, err)
+
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = srv.ListenAndServeTLS("", "")
+		err := srv.ServeTLS(listener, "", "")
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Logf("server listen error: %v", err)
 		}
@@ -183,7 +188,6 @@ func TestSetupTLSClientAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	srv := http.Server{
-		Addr: "localhost:9685",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = fmt.Fprintln(w, "Hello, client")
 		}),
@@ -192,11 +196,14 @@ func TestSetupTLSClientAuth(t *testing.T) {
 	}
 	defer func() { _ = srv.Close() }()
 
+	listener, err := net.Listen("tcp", "localhost:9685")
+	require.NoError(t, err)
+
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = srv.ListenAndServeTLS("", "")
+		err := srv.ServeTLS(listener, "", "")
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Logf("server listen error: %v", err)
 		}


### PR DESCRIPTION
### Purpose
Relax the Reply structure contract so the `code` field is optional alongside `message` and `details`. There are legitimate use cases where only `message` or only `code` is desired, and requiring `code` forces implementors to populate a field that may add no information beyond the HTTP status code. The Reply structure itself — not any particular field within it — is what distinguishes a service response from an infrastructure response, so making every field optional is consistent with the rest of the spec.

### Implementation
- Change `Code` from Required to Optional in the Reply Structure section and add a clarifying paragraph stating any combination of fields is valid, with a pointer to Infrastructure Errors for the rationale.
- Minor spec tweaks carried on this branch: correct title from "V3" back to "V2", bump `Server: DUH-RPC/1.0` examples to `2.0`, and tighten wording from "HTTP response code" to "HTTP response status code" in the Infrastructure Errors section.