### PR TITLE
Add X-DUH-Version header and content endpoint functions

### DIFF
--- a/client.go
+++ b/client.go
@@ -275,6 +275,42 @@ func (c *Client) DoBytes(ctx context.Context, req *http.Request) (io.ReadCloser,
 	return resp.Body, nil
 }
 
+// DoContent sends the request and buffers the response body into the caller-provided buf.
+// On success it returns the response headers (including Content-Type and X-RPC-* metadata).
+// On non-200 it returns nil headers and the classified error (service or infra).
+// Unlike DoBytes, DoContent accepts any Content-Type on 200 and eagerly buffers the body.
+func (c *Client) DoContent(ctx context.Context, req *http.Request, buf *bytes.Buffer) (http.Header, error) {
+	req = req.WithContext(ctx)
+
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, NewClientError("during client.Do(): %w", err, map[string]string{
+			DetailsHttpUrl:    req.URL.String(),
+			DetailsHttpMethod: req.Method,
+		})
+	}
+
+	if resp.StatusCode != CodeOK {
+		return nil, handleErrorResponse(req, resp)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if _, err := io.Copy(buf, resp.Body); err != nil {
+		return nil, &ClientError{
+			err: fmt.Errorf("while reading response body: %w", err),
+			details: map[string]string{
+				DetailsHttpUrl:    req.URL.String(),
+				DetailsHttpMethod: req.Method,
+				DetailsHttpStatus: resp.Status,
+			},
+			code:     strconv.Itoa(CodeClientError),
+			httpCode: CodeClientError,
+		}
+	}
+
+	return resp.Header, nil
+}
+
 // unmarshalForMediaType returns the appropriate unmarshal function for the given
 // Content-Type header value. Returns false if the media type is not recognized.
 func unmarshalForMediaType(contentType string) (func([]byte, proto.Message) error, bool) {

--- a/client.go
+++ b/client.go
@@ -307,13 +307,52 @@ func handleErrorResponse(req *http.Request, resp *http.Response) error {
 		}
 	}
 
+	// Step 1: Content-Type-based detection (primary signal, preserves backward compatibility
+	// with old servers that do not send X-DUH-Version).
 	unmarshalFn, ok := unmarshalForMediaType(resp.Header.Get("Content-Type"))
-	if !ok {
+	if ok {
+		var reply v1.Reply
+		if err := unmarshalFn(body.Bytes(), &reply); err != nil {
+			return NewInfraError(req, resp, body.Bytes())
+		}
+		return NewReplyError(req, resp, &reply)
+	}
+
+	// Step 2: X-DUH-Version header fallback. Used when Content-Type is unrecognized
+	// (e.g., content endpoints where middleware may overwrite Content-Type).
+	if resp.Header.Get(HeaderDUHVersion) != "" {
+		var reply v1.Reply
+		// Try JSON first (spec default), then protobuf.
+		if err := json.Unmarshal(body.Bytes(), &reply); err != nil {
+			if err := proto.Unmarshal(body.Bytes(), &reply); err != nil {
+				// Header present but body is not a valid Reply -- malformed service response.
+				return NewInfraError(req, resp, body.Bytes())
+			}
+		}
+		return NewReplyError(req, resp, &reply)
+	}
+
+	// Step 3: No Content-Type signal and no version header. Classify by HTTP status code
+	// per the spec's infrastructure error rules (§Infrastructure Errors):
+	// 5xx and 404 are the codes infrastructure components produce when a request fails
+	// to reach the service -- these are retried.
+	// Other status codes (400, 401, 403, etc.) indicate a non-conforming service, not
+	// infrastructure -- these are NOT retried.
+	code := resp.StatusCode
+	if code/100 == 5 || code == CodeNotFound {
 		return NewInfraError(req, resp, body.Bytes())
 	}
-	var reply v1.Reply
-	if err := unmarshalFn(body.Bytes(), &reply); err != nil {
-		return NewInfraError(req, resp, body.Bytes())
+	return &ClientError{
+		details: map[string]string{
+			DetailsHttpCode:   strconv.Itoa(resp.StatusCode),
+			DetailsHttpBody:   body.String(),
+			DetailsHttpUrl:    req.URL.String(),
+			DetailsHttpStatus: resp.Status,
+			DetailsHttpMethod: req.Method,
+		},
+		msg:          body.String(),
+		code:         strconv.Itoa(resp.StatusCode),
+		httpCode:     resp.StatusCode,
+		isInfraError: false,
 	}
-	return NewReplyError(req, resp, &reply)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package duh_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -423,6 +424,83 @@ func TestDoBytesErrors(t *testing.T) {
 		rc, err := c.DoBytes(ctx, req)
 		require.Error(t, err)
 		require.Nil(t, rc)
+
+		var ce *duh.ClientError
+		require.True(t, errors.As(err, &ce))
+		assert.Equal(t, duh.CodeClientError, ce.HTTPCode())
+	})
+}
+
+func TestDoContentErrors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	for _, tt := range []struct {
+		name     string
+		handler  http.HandlerFunc
+		wantCode int
+		isInfra  bool
+		checkMsg string
+	}{
+		{
+			name: "ServerReturns400WithReplyBody",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				reply := &v1.Reply{
+					Code:    "400",
+					Message: "bad request: invalid content",
+				}
+				b, _ := json.Marshal(reply)
+				w.Header().Set("Content-Type", duh.ContentTypeJSON)
+				w.Header().Set(duh.HeaderDUHVersion, duh.DUHVersion)
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(b)
+			},
+			wantCode: http.StatusBadRequest,
+			checkMsg: "bad request: invalid content",
+		},
+		{
+			name: "ServerReturns502WithNoReplyOrHeader",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte("upstream error"))
+			},
+			wantCode: http.StatusBadGateway,
+			isInfra:  true,
+			checkMsg: "upstream error",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			c := &duh.Client{Client: &http.Client{}}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/content.download", nil)
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			headers, err := c.DoContent(ctx, req, &buf)
+			require.Error(t, err)
+			require.Nil(t, headers)
+
+			var ce *duh.ClientError
+			require.True(t, errors.As(err, &ce))
+			assert.Equal(t, tt.wantCode, ce.HTTPCode())
+			assert.Contains(t, ce.Message(), tt.checkMsg)
+			assert.Equal(t, tt.isInfra, ce.IsInfraError())
+		})
+	}
+
+	// Transport failure
+	t.Run("TransportFailure", func(t *testing.T) {
+		c := &duh.Client{Client: &http.Client{}}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost:1/v1/content.download", nil)
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		headers, err := c.DoContent(ctx, req, &buf)
+		require.Error(t, err)
+		require.Nil(t, headers)
 
 		var ce *duh.ClientError
 		require.True(t, errors.As(err, &ce))

--- a/client_test.go
+++ b/client_test.go
@@ -259,6 +259,7 @@ func TestDoStreamErrors(t *testing.T) {
 				}
 				b, _ := json.Marshal(reply)
 				w.Header().Set("Content-Type", duh.ContentTypeJSON)
+				w.Header().Set(duh.HeaderDUHVersion, duh.DUHVersion)
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(b)
 			},
@@ -347,6 +348,7 @@ func TestDoBytesErrors(t *testing.T) {
 				}
 				b, _ := json.Marshal(reply)
 				w.Header().Set("Content-Type", duh.ContentTypeJSON)
+				w.Header().Set(duh.HeaderDUHVersion, duh.DUHVersion)
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write(b)
 			},
@@ -426,4 +428,169 @@ func TestDoBytesErrors(t *testing.T) {
 		require.True(t, errors.As(err, &ce))
 		assert.Equal(t, duh.CodeClientError, ce.HTTPCode())
 	})
+}
+
+func TestVersionHeaderOnReply(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "200 OK", statusCode: duh.CodeOK},
+		{name: "400 Bad Request", statusCode: duh.CodeBadRequest},
+		{name: "500 Internal Error", statusCode: duh.CodeInternalError},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				duh.Reply(w, r, tt.statusCode, &v1.Reply{Code: "200", Message: "ok"})
+			}))
+			defer server.Close()
+
+			resp, err := http.Post(server.URL+"/v1/test", duh.ContentTypeJSON, nil)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			assert.Equal(t, duh.DUHVersion, resp.Header.Get(duh.HeaderDUHVersion))
+		})
+	}
+}
+
+func TestVersionHeaderOnStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleStream(w, r, func(r *http.Request, sw duh.StreamWriter) error {
+			return sw.Close(nil)
+		})
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	// Use raw http.Client to access resp.Header directly -- DoStream returns a
+	// StreamReader interface that does not expose the underlying *http.Response.
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, duh.DUHVersion, resp.Header.Get(duh.HeaderDUHVersion))
+}
+
+func TestInfraDetectionByHeader(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	for _, tt := range []struct {
+		name        string
+		handler     http.HandlerFunc
+		wantCode    int
+		isInfra     bool
+		isServiceOK bool // true when we expect a service error (not infra)
+	}{
+		{
+			// Recognized Content-Type + Reply body = service error regardless of header.
+			// This backward-compat path handles old servers (no X-DUH-Version header).
+			name: "RecognizedContentTypeNoHeader",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				reply := &v1.Reply{Code: "400", Message: "service error via content-type"}
+				b, _ := json.Marshal(reply)
+				w.Header().Set("Content-Type", duh.ContentTypeJSON)
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(b)
+			},
+			wantCode:    http.StatusBadRequest,
+			isInfra:     false,
+			isServiceOK: true,
+		},
+		{
+			// Unrecognized Content-Type + X-DUH-Version header = service error (header fallback).
+			name: "UnrecognizedContentTypeWithHeader",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				reply := &v1.Reply{Code: "400", Message: "service error via header fallback"}
+				b, _ := json.Marshal(reply)
+				w.Header().Set("Content-Type", "text/html")
+				w.Header().Set(duh.HeaderDUHVersion, duh.DUHVersion)
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(b)
+			},
+			wantCode:    http.StatusBadRequest,
+			isInfra:     false,
+			isServiceOK: true,
+		},
+		{
+			// Unrecognized Content-Type + no header + 5xx = infra error (retried).
+			name: "UnrecognizedContentTypeNoHeaderOn5xx",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte("upstream timeout"))
+			},
+			wantCode: http.StatusBadGateway,
+			isInfra:  true,
+		},
+		{
+			// Unrecognized Content-Type + no header + 404 = infra error (retried per RetryableInfraCodes).
+			name: "UnrecognizedContentTypeNoHeaderOn404",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("Not Found"))
+			},
+			wantCode: http.StatusNotFound,
+			isInfra:  true,
+		},
+		{
+			// Unrecognized Content-Type + no header + 400 = non-conforming service error (NOT retried).
+			name: "UnrecognizedContentTypeNoHeaderOn400",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("bad input"))
+			},
+			wantCode: http.StatusBadRequest,
+			isInfra:  false,
+		},
+		{
+			// 404 with X-DUH-Version header = service error (not infra, not retried).
+			name: "404WithVersionHeader",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				reply := &v1.Reply{Code: "404", Message: "resource not found"}
+				b, _ := json.Marshal(reply)
+				w.Header().Set("Content-Type", duh.ContentTypeJSON)
+				w.Header().Set(duh.HeaderDUHVersion, duh.DUHVersion)
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write(b)
+			},
+			wantCode:    http.StatusNotFound,
+			isInfra:     false,
+			isServiceOK: true,
+		},
+		{
+			// 404 without X-DUH-Version header and unrecognized content-type = infra error (retried).
+			name: "404WithoutVersionHeader",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("Not Found"))
+			},
+			wantCode: http.StatusNotFound,
+			isInfra:  true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			c := &duh.Client{Client: &http.Client{}}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test", nil)
+			require.NoError(t, err)
+
+			err = c.Do(req, &v1.Reply{})
+			require.Error(t, err)
+
+			var ce *duh.ClientError
+			require.True(t, errors.As(err, &ce))
+			assert.Equal(t, tt.wantCode, ce.HTTPCode())
+			assert.Equal(t, tt.isInfra, ce.IsInfraError())
+		})
+	}
 }

--- a/demo/client.go
+++ b/demo/client.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/duh-rpc/duh.go/v2"
+	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
 	json "google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -97,6 +98,36 @@ func (c *Client) DownloadBytes(ctx context.Context) (io.ReadCloser, error) {
 
 	r.Header.Set("Accept", duh.ContentOctetStream)
 	return c.DoBytes(ctx, r)
+}
+
+// UploadContent uploads raw content to the service at the given path.
+// The contentType is sent as the request Content-Type and path is sent in the X-RPC-Path header.
+func (c *Client) UploadContent(ctx context.Context, path string, contentType string, body []byte) error {
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/%s", c.endpoint, "v1/content.upload"), bytes.NewReader(body))
+	if err != nil {
+		return duh.NewClientError("", err, nil)
+	}
+	r.Header.Set("Content-Type", contentType)
+	r.Header.Set("X-RPC-Path", path)
+	return c.Do(r, &v1.Reply{})
+}
+
+// DownloadContent downloads content from the service at the given path.
+// Returns the response headers (including Content-Type) and any error.
+// The body is written into the caller-provided buf.
+func (c *Client) DownloadContent(ctx context.Context, path string, buf *bytes.Buffer) (http.Header, error) {
+	payload, err := json.Marshal(&ContentDownloadRequest{Path: path})
+	if err != nil {
+		return nil, duh.NewClientError("while marshaling request payload: %w", err, nil)
+	}
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/%s", c.endpoint, "v1/content.download"), bytes.NewReader(payload))
+	if err != nil {
+		return nil, duh.NewClientError("", err, nil)
+	}
+	r.Header.Set("Content-Type", duh.ContentTypeJSON)
+	return c.DoContent(ctx, r, buf)
 }
 
 // RenderPixel sends a request to the service which calculates the pixel color of a Mandelbrot

--- a/demo/demo.pb.go
+++ b/demo/demo.pb.go
@@ -356,6 +356,53 @@ func (x *Event) GetMessage() string {
 	return ""
 }
 
+type ContentDownloadRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Path string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+}
+
+func (x *ContentDownloadRequest) Reset() {
+	*x = ContentDownloadRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_demo_demo_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ContentDownloadRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContentDownloadRequest) ProtoMessage() {}
+
+func (x *ContentDownloadRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_demo_demo_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContentDownloadRequest.ProtoReflect.Descriptor instead.
+func (*ContentDownloadRequest) Descriptor() ([]byte, []int) {
+	return file_demo_demo_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ContentDownloadRequest) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
 var File_demo_demo_proto protoreflect.FileDescriptor
 
 var file_demo_demo_proto_rawDesc = []byte{
@@ -383,9 +430,12 @@ var file_demo_demo_proto_rawDesc = []byte{
 	0x08, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x52,
 	0x08, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x6d, 0x65, 0x73,
 	0x73, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x6d, 0x65, 0x73, 0x73,
-	0x61, 0x67, 0x65, 0x42, 0x23, 0x5a, 0x21, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
-	0x6d, 0x2f, 0x64, 0x75, 0x68, 0x2d, 0x72, 0x70, 0x63, 0x2f, 0x64, 0x75, 0x68, 0x2e, 0x67, 0x6f,
-	0x2f, 0x76, 0x32, 0x2f, 0x64, 0x65, 0x6d, 0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x61, 0x67, 0x65, 0x22, 0x2c, 0x0a, 0x16, 0x43, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74, 0x44, 0x6f,
+	0x77, 0x6e, 0x6c, 0x6f, 0x61, 0x64, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x12, 0x0a,
+	0x04, 0x70, 0x61, 0x74, 0x68, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x70, 0x61, 0x74,
+	0x68, 0x42, 0x23, 0x5a, 0x21, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f,
+	0x64, 0x75, 0x68, 0x2d, 0x72, 0x70, 0x63, 0x2f, 0x64, 0x75, 0x68, 0x2e, 0x67, 0x6f, 0x2f, 0x76,
+	0x32, 0x2f, 0x64, 0x65, 0x6d, 0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -400,14 +450,15 @@ func file_demo_demo_proto_rawDescGZIP() []byte {
 	return file_demo_demo_proto_rawDescData
 }
 
-var file_demo_demo_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_demo_demo_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_demo_demo_proto_goTypes = []interface{}{
-	(*SayHelloRequest)(nil),     // 0: duh.v1.SayHelloRequest
-	(*SayHelloResponse)(nil),    // 1: duh.v1.SayHelloResponse
-	(*RenderPixelRequest)(nil),  // 2: duh.v1.RenderPixelRequest
-	(*RenderPixelResponse)(nil), // 3: duh.v1.RenderPixelResponse
-	(*ListEventsRequest)(nil),   // 4: duh.v1.ListEventsRequest
-	(*Event)(nil),               // 5: duh.v1.Event
+	(*SayHelloRequest)(nil),        // 0: duh.v1.SayHelloRequest
+	(*SayHelloResponse)(nil),       // 1: duh.v1.SayHelloResponse
+	(*RenderPixelRequest)(nil),     // 2: duh.v1.RenderPixelRequest
+	(*RenderPixelResponse)(nil),    // 3: duh.v1.RenderPixelResponse
+	(*ListEventsRequest)(nil),      // 4: duh.v1.ListEventsRequest
+	(*Event)(nil),                  // 5: duh.v1.Event
+	(*ContentDownloadRequest)(nil), // 6: duh.v1.ContentDownloadRequest
 }
 var file_demo_demo_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -495,6 +546,18 @@ func file_demo_demo_proto_init() {
 				return nil
 			}
 		}
+		file_demo_demo_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ContentDownloadRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -502,7 +565,7 @@ func file_demo_demo_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_demo_demo_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/demo/demo.proto
+++ b/demo/demo.proto
@@ -47,3 +47,7 @@ message Event {
   int64 sequence = 1;
   string message = 2;
 }
+
+message ContentDownloadRequest {
+  string path = 1;
+}

--- a/demo/handler.go
+++ b/demo/handler.go
@@ -17,8 +17,10 @@ package demo
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/duh-rpc/duh.go/v2"
+	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
 )
 
 type Handler struct {
@@ -52,6 +54,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case "/v1/bytes.download":
 		h.handleDownloadBytes(w, r)
+		return
+	case "/v1/content.upload":
+		h.handleContentUpload(w, r)
+		return
+	case "/v1/content.download":
+		h.handleContentDownload(w, r)
 		return
 	}
 	duh.ReplyWithCode(w, r, duh.CodeNotImplemented, nil, "no such method; "+r.URL.Path)
@@ -110,4 +118,43 @@ func (h *Handler) handleRenderPixel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	duh.Reply(w, r, duh.CodeOK, &resp)
+}
+
+func (h *Handler) handleContentUpload(w http.ResponseWriter, r *http.Request) {
+	body, contentType, err := duh.ReadContent(r, 10*duh.MegaByte)
+	if err != nil {
+		duh.ReplyContentError(w, r, err)
+		return
+	}
+	path := r.Header.Get("X-RPC-Path")
+	if path == "" {
+		duh.ReplyContentError(w, r, duh.NewServiceError(duh.CodeBadRequest, "X-RPC-Path header is required", nil, nil))
+		return
+	}
+	if err := h.Service.StoreContent(r.Context(), path, contentType, body); err != nil {
+		duh.ReplyContentError(w, r, err)
+		return
+	}
+	duh.Reply(w, r, duh.CodeOK, &v1.Reply{
+		Code:    strconv.Itoa(duh.CodeOK),
+		Message: "content stored",
+		Details: map[string]string{
+			"path": path,
+			"size": strconv.Itoa(len(body)),
+		},
+	})
+}
+
+func (h *Handler) handleContentDownload(w http.ResponseWriter, r *http.Request) {
+	var req ContentDownloadRequest
+	if err := duh.ReadRequest(r, &req, 5*duh.MegaByte); err != nil {
+		duh.ReplyError(w, r, err)
+		return
+	}
+	contentType, body, err := h.Service.GetContent(r.Context(), req.Path)
+	if err != nil {
+		duh.ReplyContentError(w, r, err)
+		return
+	}
+	duh.WriteContent(w, contentType, body)
 }

--- a/demo/handler.go
+++ b/demo/handler.go
@@ -101,9 +101,7 @@ func (h *Handler) listEvents(r *http.Request, stream duh.StreamWriter) error {
 }
 
 func (h *Handler) handleDownloadBytes(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", duh.ContentOctetStream)
-	w.WriteHeader(duh.CodeOK)
-	_, _ = w.Write([]byte("hello, bytes"))
+	duh.WriteContent(w, duh.ContentOctetStream, []byte("hello, bytes"))
 }
 
 func (h *Handler) handleRenderPixel(w http.ResponseWriter, r *http.Request) {

--- a/demo/service.go
+++ b/demo/service.go
@@ -17,6 +17,7 @@ package demo
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/duh-rpc/duh.go/v2"
 	"golang.org/x/text/cases"
@@ -25,7 +26,9 @@ import (
 
 // NewService creates a new service instance
 func NewService() *Service {
-	return &Service{}
+	return &Service{
+		content: make(map[string]contentEntry),
+	}
 }
 
 // TODO: Define abstracted errors here
@@ -33,8 +36,16 @@ func NewService() *Service {
 // ErrBadRequest
 // ErrRequestFailed
 
+type contentEntry struct {
+	contentType string
+	body        []byte
+}
+
 // Service is an example of a production ready service implementation
-type Service struct{}
+type Service struct {
+	mu      sync.RWMutex
+	content map[string]contentEntry
+}
 
 func (h *Service) SayHello(ctx context.Context, req *SayHelloRequest, resp *SayHelloResponse) error {
 	if req.Name == "" {
@@ -75,6 +86,25 @@ func (h *Service) ListEvents(ctx context.Context, req *ListEventsRequest) ([]*Ev
 		})
 	}
 	return events, nil
+}
+
+// StoreContent stores raw content identified by path.
+func (s *Service) StoreContent(_ context.Context, path string, contentType string, body []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.content[path] = contentEntry{contentType: contentType, body: body}
+	return nil
+}
+
+// GetContent retrieves previously stored content by path.
+func (s *Service) GetContent(_ context.Context, path string) (string, []byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.content[path]
+	if !ok {
+		return "", nil, duh.NewServiceError(duh.CodeNotFound, "content not found", nil, nil)
+	}
+	return entry.contentType, entry.body, nil
 }
 
 func norm(x, total int64, min, max float64) float64 {

--- a/functional_test.go
+++ b/functional_test.go
@@ -560,6 +560,97 @@ func TestListEventsStream(t *testing.T) {
 	require.NoError(t, sr.Close())
 }
 
+func TestContentUploadHappyPath(t *testing.T) {
+	server := httptest.NewServer(&demo.Handler{Service: demo.NewService()})
+	defer server.Close()
+
+	c := demo.NewClient(demo.ClientConfig{Endpoint: server.URL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	err := c.UploadContent(ctx, "/pages/home", "text/html; charset=utf-8", []byte("<html><body>Hello</body></html>"))
+	require.NoError(t, err)
+}
+
+func TestContentDownloadHappyPath(t *testing.T) {
+	server := httptest.NewServer(&demo.Handler{Service: demo.NewService()})
+	defer server.Close()
+
+	c := demo.NewClient(demo.ClientConfig{Endpoint: server.URL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	const htmlBody = "<html><body>Hello</body></html>"
+	require.NoError(t, c.UploadContent(ctx, "/pages/home", "text/html; charset=utf-8", []byte(htmlBody)))
+
+	var buf bytes.Buffer
+	headers, err := c.DownloadContent(ctx, "/pages/home", &buf)
+	require.NoError(t, err)
+	require.NotNil(t, headers)
+
+	assert.Equal(t, htmlBody, buf.String())
+	assert.Equal(t, "text/html; charset=utf-8", headers.Get("Content-Type"))
+	assert.Equal(t, duh.DUHVersion, headers.Get(duh.HeaderDUHVersion))
+}
+
+func TestContentUploadErrors(t *testing.T) {
+	server := httptest.NewServer(&demo.Handler{Service: demo.NewService()})
+	defer server.Close()
+
+	c := demo.NewClient(demo.ClientConfig{Endpoint: server.URL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	for _, tt := range []struct {
+		name        string
+		path        string
+		contentType string
+		body        []byte
+		wantMsg     string
+	}{
+		{
+			name:        "missing X-RPC-Path header",
+			path:        "",
+			contentType: "text/html",
+			body:        []byte("<html></html>"),
+			wantMsg:     "X-RPC-Path header is required",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.UploadContent(ctx, tt.path, tt.contentType, tt.body)
+			require.Error(t, err)
+
+			var duhErr *duh.ClientError
+			require.True(t, errors.As(err, &duhErr))
+			assert.Equal(t, duh.CodeBadRequest, duhErr.HTTPCode())
+			assert.Contains(t, duhErr.Message(), tt.wantMsg)
+		})
+	}
+}
+
+func TestContentDownloadNotFound(t *testing.T) {
+	server := httptest.NewServer(&demo.Handler{Service: demo.NewService()})
+	defer server.Close()
+
+	c := demo.NewClient(demo.ClientConfig{Endpoint: server.URL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	var buf bytes.Buffer
+	headers, err := c.DownloadContent(ctx, "/no/such/path", &buf)
+	require.Error(t, err)
+	require.Nil(t, headers)
+
+	var ce *duh.ClientError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, duh.CodeNotFound, ce.HTTPCode())
+	assert.False(t, ce.IsInfraError())
+}
+
 // TODO: Update the benchmark tests
 
 // TODO: DUH-RPC Validation Test for any endpoint

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.2
 require (
 	github.com/kapetan-io/tackle v0.1.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/net v0.53.0
-	golang.org/x/text v0.36.0
+	golang.org/x/net v0.55.0
+	golang.org/x/text v0.37.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
-golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
-golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
-golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/service.go
+++ b/service.go
@@ -34,6 +34,9 @@ const (
 	ContentOctetStream    = "application/octet-stream"
 	ContentStreamJSON     = "application/duh-stream+json"
 	ContentStreamProtoBuf = "application/duh-stream+protobuf"
+
+	HeaderDUHVersion = "X-DUH-Version"
+	DUHVersion       = "2.0"
 )
 
 var (
@@ -130,9 +133,17 @@ func Reply(w http.ResponseWriter, r *http.Request, code int, resp proto.Message)
 		return
 	}
 	w.Header().Set("Content-Type", contentType)
-	w.Header().Set("X-Content-Type-Options", "nosniff")
+	setServiceHeaders(w)
 	w.WriteHeader(code)
 	_, _ = w.Write(b)
+}
+
+// setServiceHeaders sets the standard DUH service response headers.
+// Called by Reply and WriteContent to ensure all service responses
+// include the version header and content-type options.
+func setServiceHeaders(w http.ResponseWriter) {
+	w.Header().Set(HeaderDUHVersion, DUHVersion)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
 
 // TrimSuffix trims everything after the first separator is found

--- a/service.go
+++ b/service.go
@@ -138,6 +138,48 @@ func Reply(w http.ResponseWriter, r *http.Request, code int, resp proto.Message)
 	_, _ = w.Write(b)
 }
 
+// ReadContent reads the raw request body and returns the bytes, the raw Content-Type header
+// value, and any error. Unlike ReadRequest, the Content-Type is not normalized — content
+// endpoints may need MIME parameters like charset=utf-8.
+// A limit of 0 means no limit is applied. Empty bodies and empty Content-Type are not errors.
+func ReadContent(r *http.Request, limit int64) ([]byte, string, error) {
+	var b bytes.Buffer
+	body := r.Body
+	defer func() { _ = body.Close() }()
+
+	if limit > 0 {
+		body = NewLimitReader(body, limit)
+	}
+
+	_, err := io.Copy(&b, body)
+	if err != nil {
+		var e Error
+		if errors.As(err, &e) {
+			return nil, "", NewServiceError(e.HTTPCode(), fmt.Sprintf("request body %s", e.Message()), nil, nil)
+		}
+		return nil, "", NewServiceError(CodeInternalError, "", err, nil)
+	}
+
+	return b.Bytes(), r.Header.Get("Content-Type"), nil
+}
+
+// WriteContent writes a raw content response with the given Content-Type and body.
+// It sets X-DUH-Version and X-Content-Type-Options headers via setServiceHeaders.
+func WriteContent(w http.ResponseWriter, contentType string, body []byte) {
+	w.Header().Set("Content-Type", contentType)
+	setServiceHeaders(w)
+	w.WriteHeader(CodeOK)
+	_, _ = w.Write(body)
+}
+
+// ReplyContentError writes an error Reply for content endpoint errors.
+// It delegates to ReplyError so the Accept header is respected and the version header is set.
+// This function exists as a named entry point for content endpoint handlers, parallel to
+// ReplyError for structured handlers, allowing future content-specific behavior.
+func ReplyContentError(w http.ResponseWriter, r *http.Request, err error) {
+	ReplyError(w, r, err)
+}
+
 // setServiceHeaders sets the standard DUH service response headers.
 // Called by Reply and WriteContent to ensure all service responses
 // include the version header and content-type options.

--- a/streaming.go
+++ b/streaming.go
@@ -124,6 +124,8 @@ func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Req
 	}
 
 	w.Header().Set("Content-Type", accept)
+	w.Header().Set(HeaderDUHVersion, DUHVersion)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 
 	sw := &streamWriter{
 		w:       stream.NewWriter(w),


### PR DESCRIPTION
### Purpose

Adds two related capabilities to the duh.go library:

1. **X-DUH-Version header** — Every service response now includes `X-DUH-Version: 2.0`, providing a universal signal that a response came from a DUH service regardless of Content-Type. The client uses Content-Type as the primary detection signal and falls back to this header when Content-Type is unrecognized (e.g., content endpoints returning `text/html`). Infrastructure error classification is scoped to 5xx and 404 only per the spec.

2. **Content endpoints** — New server and client functions for endpoints where the request or response body is opaque content (HTML, images, etc.) rather than a structured proto message.

**New server-side API:**
```go
// Read raw request body without Content-Type normalization
body, contentType, err := duh.ReadContent(r, maxBytes)

// Write raw content with service headers (X-DUH-Version, X-Content-Type-Options)
duh.WriteContent(w, "text/html; charset=utf-8", htmlBytes)

// Error replies for content endpoint handlers
duh.ReplyContentError(w, r, err)
```

**New client-side API:**
```go
var buf bytes.Buffer
headers, err := client.DoContent(ctx, req, &buf)
contentType := headers.Get("Content-Type")
metadata := headers.Get("X-RPC-Path")
```

The demo includes content upload/download endpoints showing the full pattern, and `handleDownloadBytes` is refactored to use `WriteContent`.

### Implementation

- **service.go**: Added `HeaderDUHVersion`/`DUHVersion` constants, `setServiceHeaders` helper called by `Reply` and `WriteContent`. Added `ReadContent` (raw body reader), `WriteContent` (raw content writer), and `ReplyContentError` (delegates to `ReplyError`)
- **streaming.go**: Updated `HandleStream` to set `X-DUH-Version` and `X-Content-Type-Options: nosniff`
- **client.go**: Rewrote `handleErrorResponse` with three-step detection: Content-Type first (backward compat), `X-DUH-Version` header fallback, then status-code classification (5xx/404 = infra, others = non-conforming). Added `DoContent` method that buffers response body and returns `http.Header`
- **demo/**: Added `ContentDownloadRequest` proto, content upload/download handlers and client methods, in-memory content storage with `sync.RWMutex`. Refactored `handleDownloadBytes` to use `WriteContent`
- **Tests**: Added `TestVersionHeaderOnReply`, `TestVersionHeaderOnStream`, `TestInfraDetectionByHeader`, `TestDoContentErrors`, `TestContentUploadHappyPath`, `TestContentDownloadHappyPath`, `TestContentUploadErrors`, `TestContentDownloadNotFound`