### PR TITLE
Rewrite why-not-rest.md and clean up docs style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DUH-RPC - Duh, Use Http for RPC
+# DUH-RPC (Duh, Use Http for RPC)
 
 [![Go Version](https://img.shields.io/github/go-mod/go-version/duh-rpc/duh.go)](https://golang.org/dl/)
 [![CI Status](https://github.com/duh-rpc/duh.go/workflows/CI/badge.svg)](https://github.com/duh-rpc/duh.go/actions)
@@ -7,11 +7,11 @@
 
 **DUH-RPC is gRPC without the framework.**
 
-gRPC is fast for two reasons: protobuf instead of JSON, and matching a method string instead of parsing a
-route with an HTTP router. DUH-RPC keeps both of the things that makes gRPC fast, BUT drops the framework.
+gRPC is fast for two reasons. Protobuf instead of JSON, and matching a method string instead of parsing a
+route with an HTTP router. DUH-RPC keeps both of the things that make gRPC fast, BUT drops the framework.
 No generated clients, no HTTP/2 trailers, no hidden features. Just protobuf over plain HTTP.
 
-*DUH-RPC simply says this: You don't need a fancy framework to get the performance of GRPC, just don't do slow things
+*DUH-RPC simply says this. You don't need a fancy framework to get the performance of gRPC, just don't do slow things
 with HTTP!*
 
 #### One client for all services
@@ -27,11 +27,11 @@ client.Post(ctx, "/v1/users.create", &CreateUserRequest{...}, &userResp)
 ```
 
 #### Plain HTTP, no trailers
-Both gRPC and DUH use POST with names as the endpoint route, and carrying the same protobuf bytes. gRPC wraps it
+Both gRPC and DUH use POST with names as the endpoint route, and carry the same protobuf bytes. gRPC wraps it
 in HTTP/2 frames and puts the status in a trailer. This is why curl and browsers can't speak it without a
-proxy. DUH is a plain POST any HTTP client already makes
+proxy. DUH is a plain POST any HTTP client already makes.
 
-gRPC: HTTP/2 + trailers
+gRPC (HTTP/2 + trailers)
 ```http
 POST /say.Greeter/SayHello   HTTP/2
 content-type: application/grpc+proto
@@ -39,10 +39,10 @@ te: trailers
 
 <5-byte prefix><protobuf bytes>
 ─────────────────────────────
-grpc-status: 0                 (HTTP/2 trailer)
+grpc-status: 0       (HTTP/2 trailer)
 ```
-DUH-RPC on the Wire is straight HTTP 1.1 or HTTP/2
-```
+DUH-RPC on the wire is straight HTTP 1.1 or HTTP/2
+```http
 POST /v1/say.hello           HTTP/1.1
 Content-Type: application/protobuf
 
@@ -57,7 +57,6 @@ Every error uses the same Reply structure, so clients, libraries, and even proxi
 handle failures uniformly, without custom headers or out-of-band signals:
 ```json
 HTTP/1.1 400
-
 {
   "code":    "CARD_DECLINED",
   "message": "declined due to fraud",
@@ -65,10 +64,10 @@ HTTP/1.1 400
 }
 ```
 
-#### One HTTP API, everywhere
+#### One HTTP Transport, everywhere
 - One transport for internal AND public APIs
 - No generated client
-- HTTP API Works with Curl, Postman, etc..
+- HTTP API works with Curl, Postman, etc.
 - Fully compatible with OpenAPI tooling and docs
 - In an apples to apples comparison it can [outperform Go's gRPC implementation](https://github.com/duh-rpc/duh-benchmarks.go)
   
@@ -80,13 +79,13 @@ HTTP/1.1 400
 }
 ```
 ## Who is using RPC style APIs in production?
-- Slack API - Take a look at the [Slack API Methods](https://docs.slack.dev/reference/methods)
-- Dropbox API v2 - POST-only RPC endpoints (`/2/files/list_folder`, `/2/users/get_current_account`). Dropbox engineer: ["the API definitely isn't REST"](https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/Dropbox-REST-API-mostly-using-POST/td-p/115120)
-- Ashby - Public recruiting API uses `/CATEGORY.method` RPC-style paths with POST-only endpoints. They've [written about why they chose RPC](https://medium.com/mergeapi/an-interview-with-ashbys-aaron-norby-on-rpc-apis-f658134597bc) over REST or GraphQL.
-- DocMost - API uses `POST /subject/method` style https://docmost.com/api-docs
+- Slack API. See the [Slack API Methods](https://docs.slack.dev/reference/methods)
+- Dropbox API v2 uses POST-only RPC endpoints (`/2/files/list_folder`, `/2/users/get_current_account`). Dropbox engineer: ["the API definitely isn't REST"](https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/Dropbox-REST-API-mostly-using-POST/td-p/115120)
+- Ashby's public recruiting API uses `/CATEGORY.method` RPC-style paths with POST-only endpoints. They've [written about why they chose RPC](https://medium.com/mergeapi/an-interview-with-ashbys-aaron-norby-on-rpc-apis-f658134597bc) over REST or GraphQL.
+- DocMost's API uses `POST /subject/method` style https://docmost.com/api-docs
 - Have you seen others? Open a PR, and add it here!
 
-> REMEMBER: You don't need to follow the DUH-RPC spec, just design you own RPC style HTTP API!
+> REMEMBER, you don't need to follow the DUH-RPC spec, just design your own RPC style HTTP API!
 
 ## Quick Start
 The DUH-RPC cli tool uses OpenAPI to build high-performance RPC-style HTTP endpoints in Go.
@@ -123,15 +122,15 @@ make test
 
 See the [DUH-RPC CLI](https://github.com/duh-rpc/duh-cli) repo for complete documentation on the DUH-RPC CLI.
 
-> REMEMBER: You don't need the CLI to follow the RPC style. The CLI is just a convenient way to generate
+> REMEMBER, you don't need the CLI to follow the RPC style. The CLI is just a convenient way to generate
 > boilerplate code and documentation.
 
 ## Why not REST?
 Teams adopting RPC are usually fleeing REST. The core problem isn't any single REST decision, it's that
 REST gives you *many ways* to do everything, and every choice is a place teams diverge. RPC removes the
-decision: there's one way, and it's the same on every endpoint.
+decision. There's one way, and it's the same on every endpoint.
 
-| Question          | REST — pick one                                            | DUH-RPC |
+| Question          | REST (pick one)                                            | DUH-RPC |
 |-------------------|------------------------------------------------------------|-------------------|
 | Where's the input?| path vars, `?query`, header, form, json body, cookie       | json body         |
 | Which verb?       | `GET`, `POST`, `PUT`, `PATCH`, `DELETE`                    | `POST`            |
@@ -149,12 +148,12 @@ DUH-RPC is a simple RPC-over-HTTP spec using POST-only endpoints.
 
 > The DUH-RPC spec is intentionally opinionated. You don't have to adopt it wholesale, but following it means there is less for your team to think about. The conventions are fixed, so developers can focus on building rather than debating API design decisions. Follow the spec and you get consistent, well-structured APIs by default.
 
-1. **RPC style path Format**: `/v1/{subject}.{method}`
-   - Example: `/v1/users.create`, `/v2/user.get`, `/v1/users.list`
-   - An optional `problem-domain` namespace segment is supported for grouping: e.g. `/v1/billing/invoices.list`
-   - Versioning format is not prescribed — `v1`, `V1`, or `v1.2.1` are all acceptable; versioning in some form is strongly recommended
-   - Subject and method: lowercase letters, digits, hyphens, underscores
-2. **POST Only** - All operations use POST, even reads
+1. **RPC style path Format** is `/v1/{subject}.{method}`
+   - For example, `/v1/users.create`, `/v2/user.get`, `/v1/users.list`
+   - An optional `problem-domain` namespace segment is supported for grouping (e.g. `/v1/billing/invoices.list`)
+   - Versioning format is not prescribed (`v1`, `V1`, or `v1.2.1` are all acceptable); versioning in some form is strongly recommended
+   - Subject and method use lowercase letters, digits, hyphens, underscores
+2. **POST Only** (all operations use POST, even reads)
    - No GET, PUT, DELETE, PATCH
 3. **Request Body Required**
    - All input data goes in the body
@@ -162,24 +161,14 @@ DUH-RPC is a simple RPC-over-HTTP spec using POST-only endpoints.
 4. **Content Types**
    - application/json
    - application/protobuf
-   - Additional content types for streaming are supported — see [streaming.md](docs/streaming.md)
-5. **Status Codes** - Only these are allowed:
-   - 2xx: 200 only
-   - 4xx: 400, 401, 403, 404, 409, 429, 452-455
-   - 5xx: 500, 501
-6. **Success Response** - All operations MUST define a 200 response with content
-7. **Consistent Error Schema** - All error responses follow a similar schema. The `code` field is always a string — either a numeric string or a semantic string:
-```json
-{ 
-    "code": "2404",
-    "message": "this is the error message",
-    "details": {
-        "url": "https://example.com/docs/errors/2404",
-        "subcode": "1012.1"
-    }
-}
-```
-Semantic strings are also valid when there is no appropriate HTTP status code mapping:
+   - Additional content types for streaming are supported; see [streaming.md](docs/streaming.md)
+5. **Status Codes** (only these are allowed):
+   - 2xx (200 only)
+   - 4xx (400, 401, 403, 404, 409, 429, 452-455)
+   - 5xx (500, 501)
+6. **Success Response** (all operations MUST define a 200 response with content)
+7. **Consistent Error Schema** (all error responses follow a similar schema). The `code` field is always a string, either a numeric string or a semantic string:
+
 ```json
 {
     "code": "CARD_DECLINED",
@@ -191,16 +180,16 @@ Semantic strings are also valid when there is no appropriate HTTP status code ma
 }
 ```
 
-#### DUH-RPC is:
+#### DUH-RPC is
 
-- Simple: Fixed conventions eliminate design decisions
-- RPC-style: Method calls, not resource manipulation
-- Type-safe: Works well with code generation
-- Consistent: All operations follow the same pattern
+- Simple (fixed conventions eliminate design decisions)
+- RPC-style (method calls, not resource manipulation)
+- Type-safe (works well with code generation)
+- Consistent (all operations follow the same pattern)
 
 ## When is DUH-RPC not appropriate?
 DUH-RPC, like most RPC APIs, is intended for service to service communication. It doesn't make sense to use
-DUH-RPC if your intended use case is users sharing links to be clicked. Eg.. https://www.google.com/search?q=rpc+api
+DUH-RPC if your intended use case is users sharing links to be clicked, e.g. https://www.google.com/search?q=rpc+api
 
 ## The Full DUH-RPC Spec
 You can read the full spec [here](docs/spec.md).
@@ -210,4 +199,9 @@ Also, for structured server-to-client streaming support, See [streaming.md](docs
 For more complete thoughts on gRPC versus standard HTTP in Go, see
 [Why not gRPC](docs/why-not-grpc.md).
 
-*Psst: You don't need to follow the spec, JUST use HTTP and build an RPC style API!*
+The closest sibling to DUH-RPC is [Connect](https://connectrpc.com); it's also POST-based and
+human-readable, also protobuf or JSON. The difference is that Connect is still a framework with a
+gRPC and gRPC-Web compatibility layer, and like gRPC it has no clean path for unstructured
+upload and download. DUH-RPC is just plain HTTP, and content endpoints carry opaque bytes directly.
+
+*Psst, you don't need to follow the spec, JUST use HTTP and build an RPC style API!*

--- a/docs/ai-cheatsheet.md
+++ b/docs/ai-cheatsheet.md
@@ -25,16 +25,16 @@ POST /v1/identity/sessions.create
 
 CRUD mapping:
 ```
-.create  — create a resource
-.get     — read a resource (no side effects)
-.update  — modify an existing resource
-.delete  — remove a resource
-.list    — paginated collection (see Pagination)
+.create  create a resource
+.get     read a resource (no side effects)
+.update  modify an existing resource
+.delete  remove a resource
+.list    paginated collection (see Pagination)
 ```
 
 ## Request Body
 
-- Client MUST always send a body. For JSON: `{}`. For Protobuf: empty bytes.
+- Client MUST always send a body. For JSON, send `{}`. For Protobuf, send empty bytes.
 - Server MUST always unmarshal the body unconditionally.
 
 ## Content Types
@@ -89,7 +89,7 @@ The HTTP status code is authoritative for retry and routing. The `code` field is
 | 500 | Internal Error | Yes | Service |
 | 501 | Not Implemented | No | DUH-RPC framework |
 
-When implementing a service endpoint, you will typically return: 200, 400, 404, 409, 453, 454, 500. Codes 455 and 501 are handled by the DUH-RPC framework. Codes 401, 403, and 429 are handled by auth/rate-limit middleware.
+When implementing a service endpoint, you will typically return 200, 400, 404, 409, 453, 454, 500. Codes 455 and 501 are handled by the DUH-RPC framework. Codes 401, 403, and 429 are handled by auth/rate-limit middleware.
 
 Do NOT invent new HTTP status codes. Use the `details` map for application-specific error codes.
 
@@ -101,10 +101,10 @@ An infrastructure error is a response that does NOT include the `X-DUH-Version` 
 
 | Has `X-DUH-Version`? | HTTP code | Origin | Action |
 |---|---|---|---|
-| Yes | 404 | Service — resource not found | Do not retry |
-| No | 404 | Infrastructure — service unreachable | Retry |
-| Yes | 500 | Service — internal error | Retry |
-| No | 502 | Infrastructure — gateway error | Retry |
+| Yes | 404 | Service (resource not found) | Do not retry |
+| No | 404 | Infrastructure (service unreachable) | Retry |
+| Yes | 500 | Service (internal error) | Retry |
+| No | 502 | Infrastructure (gateway error) | Retry |
 | No | 400 | Non-conforming service | Do not retry |
 
 The `X-DUH-Version` check is a last-resort signal. Evaluate the HTTP status code, content type, and response body first. Only check for the absence of `X-DUH-Version` on 5xx or 404 when no other rule applies.
@@ -164,7 +164,7 @@ A `429` without a Reply body is an infrastructure-level rate limit. Retry with b
 
 Cursor-based forward pagination only. No `limit`, `offset`, or `page` parameters.
 
-**Request** — nest under `pagination`:
+**Request** (nest under `pagination`):
 ```json
 {
   "pagination": {
@@ -203,7 +203,7 @@ An endpoint is paginated if its response has `items` + `pagination`. Actions lik
 ## Schema Rules
 
 - Every operation MUST have a dedicated request schema and a dedicated response schema. No sharing across operations.
-- Name schemas after their operation: `UserCreateRequest`, `UserCreateResponse`.
+- Name schemas after their operation, e.g. `UserCreateRequest`, `UserCreateResponse`.
 - No `readOnly` or `writeOnly` field annotations. Put fields in the correct schema instead.
 
 ### Protobuf Compatibility Constraints
@@ -235,7 +235,7 @@ All streaming endpoints use POST.
 ### Unstructured Streams (`application/octet-stream`)
 
 - Errors MUST be returned as a Reply **before** any bytes are sent. Once bytes flow, there is no way to inject a Reply.
-- A `200` with `Content-Type: application/octet-stream` means raw bytes — do NOT parse as Reply.
+- A `200` with `Content-Type: application/octet-stream` means raw bytes; do NOT parse as Reply.
 - Mid-stream disconnection is an infrastructure error. Client MAY retry from the beginning.
 - Resumable transfers supported via standard HTTP `Range` / `Content-Range` headers (optional).
 
@@ -243,7 +243,7 @@ All streaming endpoints use POST.
 
 A sequence of typed messages over a single HTTP response. One payload type per stream.
 
-**Wire format — length-prefix framing:**
+**Wire format (length-prefix framing):**
 ```
 [ 1 byte: flag ][ 4 bytes: uint32 big-endian length ][ N bytes: payload ]
 ```

--- a/docs/design-guide.md
+++ b/docs/design-guide.md
@@ -1,5 +1,5 @@
 # Design Guide
-This is the DUH-RPC design guide, while not appart of the specification. provides additional guidance on best 
+This is the DUH-RPC design guide. While not a part of the specification, it provides additional guidance on best
 practices to follow when implementing your own DUH-RPC endpoints.
 
 ## Pagination
@@ -18,7 +18,7 @@ For deeper understanding of pagination patterns and advanced use cases like bidi
 
 **Cursors** are opaque strings representing a position in a dataset. They should be base64-encoded and contain implementation details (like offset, ID, or timestamp) that clients should never parse. This opacity allows backend implementation changes without breaking clients.
 
-**PageInfo** is a message containing pagination metadata: `has_next_page` indicates whether more results exist, and `next_cursor` provides the cursor to fetch the next page.
+**PageInfo** is a message containing pagination metadata. `has_next_page` indicates whether more results exist, and `next_cursor` provides the cursor to fetch the next page.
 
 **Edges** (optional) are wrappers containing both a cursor and a node (the actual item). Use edges when you need per-item cursors or relationship-specific metadata.
 
@@ -124,8 +124,8 @@ message ListUsersResponse {
 ### Response Structure Reference
 
 **When to use each pattern:**
-- **Simple pattern**: Use for standard list endpoints where you only need forward pagination
-- **Connection pattern**: Use when you need per-item cursors or edge-specific metadata (e.g., friendship timestamps in social graphs)
+- **Simple pattern** for standard list endpoints where you only need forward pagination
+- **Connection pattern** when you need per-item cursors or edge-specific metadata (e.g., friendship timestamps in social graphs)
 
 **Required fields:**
 - `page_info` is required for all paginated responses
@@ -144,8 +144,8 @@ message ListUsersResponse {
 ```
 
 **Error handling:**
-- Invalid cursor: Return `400 Bad Request` with message "invalid cursor"
-- Expired cursor: Return `400 Bad Request` with message "cursor expired"
+- Invalid cursor returns `400 Bad Request` with message "invalid cursor"
+- Expired cursor returns `400 Bad Request` with message "cursor expired"
 - Use standard DUH-RPC error codes and Reply structure
 
 ### Iterator Generation Criteria
@@ -155,8 +155,8 @@ message ListUsersResponse {
 The `duh generate http` tool will automatically generate client-side iterators when a response schema contains **all** of the following:
 
 1. **A repeated field** (array of items)
-2. **At least one pagination position field**: `cursor`, `pivot`, `page`, `offset`, `has_next_page`
-3. **At least one size limit field**: `limit`, `first`, `last`
+2. **At least one pagination position field** (`cursor`, `pivot`, `page`, `offset`, `has_next_page`)
+3. **At least one size limit field** (`limit`, `first`, `last`)
 
 #### Examples that WILL generate iterators
 
@@ -221,10 +221,10 @@ message ListUsersRequest {
 **Detected Pagination Types:**
 
 The tool detects multiple pagination patterns for backward compatibility:
-- **Cursor-based**: `cursor` + `limit` (recommended and documented here)
-- **Offset-based**: `offset` + `limit` (detected but not recommended)
-- **Page-based**: `page` + `limit` (detected but not recommended)
-- **GraphQL-style**: `has_next_page` + `first`/`last` (detected)
+- **Cursor-based** uses `cursor` + `limit` (recommended and documented here)
+- **Offset-based** uses `offset` + `limit` (detected but not recommended)
+- **Page-based** uses `page` + `limit` (detected but not recommended)
+- **GraphQL-style** uses `has_next_page` + `first`/`last` (detected)
 
 All generated iterators use the same interface regardless of underlying type.
 
@@ -301,9 +301,9 @@ for iter.HasNext() {
 #### Internal Behavior
 
 Iterators track pagination state internally based on detected type:
-- **Cursor-based**: Tracks `next_cursor` from `page_info`, sends in `cursor` field of next request
-- **Offset-based**: Increments offset counter, sends in `offset` field
-- **Page-based**: Increments page counter, sends in `page` field
+- **Cursor-based** tracks `next_cursor` from `page_info`, sends in `cursor` field of next request
+- **Offset-based** increments offset counter, sends in `offset` field
+- **Page-based** increments page counter, sends in `page` field
 
 The same Next()/HasNext() interface works for all pagination types, providing a consistent developer experience.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,16 +1,18 @@
 # The DUH Spec V2
 Here we are presenting a general protocol approach to implementing RPC over HTTP. The benefit of using tried-and-true nature of HTTP for RPC allows designers to leverage the many tools and frameworks readily available to design, document, and implement high-performance HTTP APIs without overly complex client or deployment strategies.
 
-When using plain HTTP, a `404 Not Found` could mean a load balancer, API gateway, or proxy couldn't find your service at all — or it could mean your service couldn't find the requested resource. To the client, both look identical. DUH-RPC solves this with two signals: the **`X-DUH-Version` header** on every service response, and the **Reply structure** in error response bodies. If a response includes `X-DUH-Version`, it came from the service. If it does not, it came from infrastructure. This distinction drives how clients interpret errors and whether they should retry.
+The closest existing approach is [Connect](https://connectrpc.com), which also uses POST-based, human-readable RPC over HTTP with protobuf or JSON. DUH-RPC differs in two ways. Connect ships as a framework with a gRPC and gRPC-Web compatibility layer, where DUH-RPC is a convention over plain HTTP with no runtime to adopt. And like gRPC, Connect has no first-class path for unstructured upload and download; DUH-RPC's [content endpoints](#content-endpoints) carry opaque bytes in their native MIME type without a wrapping message.
+
+When using plain HTTP, a `404 Not Found` could mean a load balancer, API gateway, or proxy couldn't find your service at all; or it could mean your service couldn't find the requested resource. To the client, both look identical. DUH-RPC solves this with two signals: the **`X-DUH-Version` header** on every service response, and the **Reply structure** in error response bodies. If a response includes `X-DUH-Version`, it came from the service. If it does not, it came from infrastructure. This distinction drives how clients interpret errors and whether they should retry.
 
 The server MUST include the `X-DUH-Version` header on every response, including 200, 4xx, and 5xx. The value is the DUH-RPC spec version the service implements (e.g. `X-DUH-Version: 2.0`). Unlike the `Server` header, custom headers are not scrubbed by proxies, making this a reliable signal.
 
 DUH method calls take the form `/v1/problem-domain/subject.method`
 
-The `problem-domain` segment is an optional namespace for grouping related endpoints. Use it when endpoints need organizational separation (e.g., `/v1/billing/invoices.list`, `/v1/identity/sessions.create`). Nesting is permitted. There is no enforcement — it is purely organizational and may span multiple services or API documents.
+The `problem-domain` segment is an optional namespace for grouping related endpoints. Use it when endpoints need organizational separation (e.g., `/v1/billing/invoices.list`, `/v1/identity/sessions.create`). Nesting is permitted. There is no enforcement; it is purely organizational and may span multiple services or API documents.
 
 ### Requests
-All requests SHOULD use the POST verb with an in body request object describing the arguments of the RPC request. Because each request includes a payload in the encoding of your choice (Default to JSON) there is no need to use  any other HTTP verb other than POST.
+All requests SHOULD use the POST verb with an in body request object describing the arguments of the RPC request. Because each request includes a payload in the encoding of your choice (default to JSON) there is no need to use any HTTP verb other than POST.
 
 > In fact, if you attempt to send a payload using verbs like GET, You will find that some language frameworks assume 
 > there is no payload on GET and will not allow you to read the payload.
@@ -21,7 +23,7 @@ The name of the RPC method should be in the standard HTTP path such that it can 
 
 The client MUST always send a request body, even for methods that define no parameters. For JSON, this means sending `{}`. For Protobuf, a zero-byte body is acceptable, as an empty message unmarshals cleanly.
 
-The server MUST always read the request body, regardless of whether it is empty. For structured endpoints, this means unmarshaling into the request schema; an empty JSON body (`{}`) or zero-byte protobuf body unmarshals cleanly into an empty message. For content endpoints, this means reading the raw bytes. This keeps server-side handling unconditional — no nil-check or missing-body branch is required, and the unmarshalling overhead for an empty message is negligible.
+The server MUST always read the request body, regardless of whether it is empty. For structured endpoints, this means unmarshaling into the request schema; an empty JSON body (`{}`) or zero-byte protobuf body unmarshals cleanly into an empty message. For content endpoints, this means reading the raw bytes. This keeps server-side handling unconditional; no nil-check or missing-body branch is required, and the unmarshalling overhead for an empty message is negligible.
 
 CRUD Examples
 * `/v1/users.create`
@@ -40,27 +42,27 @@ If Methods do not act upon a collection, then you should indicate the subject th
 
 Naming it `/v1/kiss.give` instead of just `/v1/kiss` is an important future proofing action. In case you want to add other methods to `/v1/kiss`, you have a consistent API. For instance if you only had `/v1/kiss` then when you  wanted to add the ability to `blow` a kiss, your api would look like
 
-* `/v1/kiss` - Create a Kiss
-* `/v1/kiss.blow` - Blow a Kiss
+* `/v1/kiss` (Create a Kiss)
+* `/v1/kiss.blow` (Blow a Kiss)
 
 Instead of the more consistent
-* `/v1/kiss.give` - Give a Kiss
-* `/v1/kiss.blow` - Blow a Kiss
+* `/v1/kiss.give` (Give a Kiss)
+* `/v1/kiss.blow` (Blow a Kiss)
 
 ### Subject before Noun or Action
 You may have noticed that every endpoint has the subject before the action. This is intentional and is useful for  future proofing your API when you add more actions in the future. Just remember, if in doubt, design your API like Yoda would speak.
 
 ### Versioning
-DUH-RPC calls employ standard HTTP paths to make RPC calls. This approach makes versioning those methods easy and direct. This spec does NOT have an opinion on the versioning semantic used. IE: `v1` or `V1` or `v1.2.1`. It is highly recommended that all methods are versioned in some way.
+DUH-RPC calls employ standard HTTP paths to make RPC calls. This approach makes versioning those methods easy and direct. This spec does NOT have an opinion on the versioning semantic used, e.g. `v1`, `V1`, or `v1.2.1`. It is highly recommended that all methods are versioned in some way.
 
 ## Content Negotiation
 This spec defines support for only the following mime types which can be specified in the `Content-Type` or `Accept`  headers. However, since this is HTTP, service Implementors are free to add support for whatever mime type they want.
 
-* `application/json` - This MUST be used when sending or receiving JSON. The charset MUST be UTF-8
-* `application/protobuf` - This MUST be used when sending or receiving Protobuf. The charset MUST be ascii
-* `application/octet-stream` - This MUST be used when sending or receiving unstructured binary data. The charset is undefined. The client/server should receive and store the binary data in its unmodified form.
-* `application/duh-stream+json` - This MUST be used when sending or receiving a structured server-to-client stream with JSON encoded payloads. See [streaming.md](streaming.md).
-* `application/duh-stream+protobuf` - This MUST be used when sending or receiving a structured server-to-client stream with Protobuf encoded payloads. See [streaming.md](streaming.md).
+* `application/json` MUST be used when sending or receiving JSON. The charset MUST be UTF-8
+* `application/protobuf` MUST be used when sending or receiving Protobuf. The charset MUST be ascii
+* `application/octet-stream` MUST be used when sending or receiving unstructured binary data. The charset is undefined. The client/server should receive and store the binary data in its unmodified form.
+* `application/duh-stream+json` MUST be used when sending or receiving a structured server-to-client stream with JSON encoded payloads. See [streaming.md](streaming.md).
+* `application/duh-stream+protobuf` MUST be used when sending or receiving a structured server-to-client stream with Protobuf encoded payloads. See [streaming.md](streaming.md).
 > The service implementation MUST always return the content type of the response.
 
 > These content types are used by structured endpoints. Content endpoints, where the request or response body is opaque content, use the content's own MIME type. The JSON fallback rule ("server MUST ALWAYS support JSON") applies to structured and error responses, not to the content body of a content endpoint. See [Content Endpoints](#content-endpoints).
@@ -99,14 +101,14 @@ Standard replies from the service SHOULD follow a common structure. This provide
 #### Reply Structure
 The reply structure has the following fields.
 
-* **Code** (Optional) — An application-level signal controlled by the implementor. It MAY be a numeric string
+* **Code** (Optional). An application-level signal controlled by the implementor. It MAY be a numeric string
   (e.g. `"400"`, `"453"`) or a semantic string meaningful to the application (e.g. `"CARD_DECLINED"`,
-  `"RATE_LIMITED"`). The HTTP status code is the authoritative signal for retry and routing decisions — client
+  `"RATE_LIMITED"`). The HTTP status code is the authoritative signal for retry and routing decisions; client
   implementations MUST base retry logic on the HTTP status code, not the `code` field.
-* **Message** (Optional) — A human readable message.
-* **Details** (Optional) — A map of string key/value pairs providing additional context about this error, which could include a link to documentation explaining the error or additional machine-readable codes.
+* **Message** (Optional). A human readable message.
+* **Details** (Optional). A map of string key/value pairs providing additional context about this error, which could include a link to documentation explaining the error or additional machine-readable codes.
 
-All fields are optional. A Reply MAY contain only `code`, only `message`, only `details`, or any combination. The presence of a well-formed Reply structure (even an empty one) is what distinguishes a service response from an infrastructure response — see [Infrastructure Errors](#infrastructure-errors).
+All fields are optional. A Reply MAY contain only `code`, only `message`, only `details`, or any combination. The presence of a well-formed Reply structure (even an empty one) is what distinguishes a service response from an infrastructure response; see [Infrastructure Errors](#infrastructure-errors).
 
 > Although the **Reply** structure is typically used for error replies, it CAN be used in normal `200` responses when there is a desire to avoid adding a new `<MethodCall>Response` type for simple method call which has no detailed responses.
 
@@ -137,12 +139,12 @@ the HTTP status code.
 ###### Service HTTP Codes
 When you break it down by what implementation is responsible for what HTTP code, it breaks down like this.
 
-Service Implementation - 200, 400, 404, 409, 453, 454, 500
-DUH-RPC Implementation - 455, 501
+Service Implementation (200, 400, 404, 409, 453, 454, 500)
+DUH-RPC Implementation (455, 501)
 
 > `452` is a client-side code synthesized by the client SDK. It is never received over the wire. See [Client-Side Codes](#client-side-codes).
-AuthZ/AuthN Implementation - 401, 403
-RateLimit Implementation - 429
+AuthZ/AuthN Implementation (401, 403)
+RateLimit Implementation (429)
 
 #### Errors and Codes
 HTTP Status Codes should NOT be expanded for your specific use case. Instead, server implementations should add their own custom fields and codes in the standard `v1.Reply.Details` map.
@@ -205,7 +207,7 @@ A client SDK SHOULD return `452` in the following scenarios:
 | Transport failure | `http.Client.Do()` failed before a response was received (e.g. DNS failure, connection refused, unsupported scheme). |
 | Response deserialization failure | The server returned `200` but the response body could not be unmarshalled. |
 
-The first three scenarios are deterministic local failures — retrying will produce the same result. The fourth is ambiguous: it may indicate a client/server schema mismatch or a server bug. Retry is still incorrect, but implementations SHOULD surface this case distinctly from the others so it can be investigated. A deserialization failure on a `200` is a signal to examine the server, not just fix the client.
+The first three scenarios are deterministic local failures; retrying will produce the same result. The fourth is ambiguous. It may indicate a client/server schema mismatch or a server bug. Retry is still incorrect, but implementations SHOULD surface this case distinctly from the others so it can be investigated. A deserialization failure on a `200` is a signal to examine the server, not just fix the client.
 
 **Retry: False** for all `452` scenarios.
 
@@ -291,7 +293,7 @@ The retryable status codes and the conditions under which a client should retry 
 
 A stream that disconnects before any frames are received is an infrastructure error. The same retry rules as unary requests apply.
 
-A stream that disconnects after one or more data frames, without a final or error frame, is also an infrastructure error. The client MAY retry from the beginning. Whether a full retry is safe depends on the idempotency of the stream endpoint — the same principle that applies to non-idempotent unary operations applies here. If the stream endpoint encodes sequence information in the payload, the client SHOULD pass the last received sequence value in the retry request so the server can resume from the correct position. See [streaming.md](streaming.md) for details on the sequence-in-payload pattern.
+A stream that disconnects after one or more data frames, without a final or error frame, is also an infrastructure error. The client MAY retry from the beginning. Whether a full retry is safe depends on the idempotency of the stream endpoint; the same principle that applies to non-idempotent unary operations applies here. If the stream endpoint encodes sequence information in the payload, the client SHOULD pass the last received sequence value in the retry request so the server can resume from the correct position. See [streaming.md](streaming.md) for details on the sequence-in-payload pattern.
 
 A stream that terminates with a final or error frame MUST NOT be retried. The stream ended intentionally.
 
@@ -356,8 +358,8 @@ Protobuf maps require explicit key and value types. When using `additionalProper
 ### No allOf or anyOf
 `allOf` has no equivalent in protobuf and MUST NOT be used. `anyOf` introduces ambiguous typing that cannot be represented in protobuf and MUST NOT be used.
 
-### oneOf — Nested Key-Tagged Unions Only
-`oneOf` is permitted only as a nested, key-tagged union: an object with one optional `$ref` property per
+### oneOf (Nested Key-Tagged Unions Only)
+`oneOf` is permitted only as a nested, key-tagged union. It is an object with one optional `$ref` property per
 variant plus a `oneOf` of single-`required` branches and **no `discriminator`**. The present key names the
 variant and its payload nests beneath it (`{"cat_event": {"pet_name": "Whiskers"}}`). This is the one form
 that serializes identically on both the JSON and protobuf wires, because it maps directly to a protobuf
@@ -377,7 +379,7 @@ Event:
     - required: [dog_event]
 ```
 
-The **discriminated/flat `oneOf`** — a top-level `oneOf` of `$ref`/inline variants plus a `discriminator` —
+The **discriminated/flat `oneOf`** (a top-level `oneOf` of `$ref`/inline variants plus a `discriminator`)
 is **NOT permitted**. It hoists the selected variant's fields to the top level and tags them by value
 (`{"eventType": "cat", "pet_name": "Whiskers"}`), a shape no protobuf serialization can produce.
 
@@ -512,7 +514,7 @@ Paginated responses MUST include the following structure:
 When `has_next_page` is `false`, the client SHOULD NOT make a further request. When `has_next_page` is `true` and `end_cursor` is present, the client MAY request the next page by passing `end_cursor` as `pagination.after`.
 
 ### Prohibited Pagination Patterns
-The following parameter names are prohibited as they imply offset-style pagination: `limit`, `offset`, and `page` as a standalone parameter name (i.e. a top-level integer page number). The `pagination` sub-object described above is the only permitted use of pagination parameters.
+The following parameter names imply offset-style pagination and are prohibited (`limit`, `offset`, and `page` as a standalone parameter name, i.e. a top-level integer page number). The `pagination` sub-object described above is the only permitted use of pagination parameters.
 
 ### Backwards Pagination
 Forward-only pagination (`first`/`after`) is the baseline requirement. Backwards pagination (`last`/`before`) MAY be added to an endpoint without violating this spec, provided the forward pagination fields under `pagination` remain present.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,6 +1,6 @@
 ## Streaming
 
-HTTP handles request/response well. It handles streams less cleanly — not because the protocol can't do it, but because there are several ways to do it and they differ in ways that matter. DUH-RPC defines two streaming content types with distinct semantics. Picking the right one is a function of your payload type, not personal preference.
+HTTP handles request/response well. It handles streams less cleanly, not because the protocol can't do it, but because there are several ways to do it and they differ in ways that matter. DUH-RPC defines two streaming content types with distinct semantics. Picking the right one is a function of your payload type, not personal preference.
 
 | Content Type | Encoding | Use Case |
 |---|---|---|
@@ -16,7 +16,7 @@ All streaming endpoints MUST use POST, same as any other DUH-RPC method.
 
 `application/octet-stream` transfers raw bytes with no application-level framing. Use it for file downloads, binary exports, or any payload where the content is opaque to the service layer.
 
-Error handling is straightforward: once bytes start flowing there is no safe place to inject a Reply structure. Errors MUST be returned as a standard Reply response before any bytes are sent. A `200` response with `Content-Type: application/octet-stream` means the body is raw bytes — the client MUST NOT attempt to parse it as a Reply.
+Error handling is straightforward. Once bytes start flowing there is no safe place to inject a Reply structure. Errors MUST be returned as a standard Reply response before any bytes are sent. A `200` response with `Content-Type: application/octet-stream` means the body is raw bytes; the client MUST NOT attempt to parse it as a Reply.
 
 A mid-stream disconnection is an infrastructure error. The client MAY retry from the beginning.
 
@@ -26,7 +26,7 @@ Resumable transfers are supported via the standard HTTP `Range` and `Content-Ran
 
 ### Structured Streams
 
-Structured streaming sends a sequence of typed messages over a single HTTP response. Two content types support this: `application/duh-stream+json` for JSON payloads and `application/duh-stream+protobuf` for Protobuf payloads. They share the same conceptual model and wire format — only the payload encoding differs.
+Structured streaming sends a sequence of typed messages over a single HTTP response. Two content types support this. `application/duh-stream+json` carries JSON payloads and `application/duh-stream+protobuf` carries Protobuf payloads. They share the same conceptual model and wire format; only the payload encoding differs.
 
 A structured streaming endpoint carries exactly one payload type. The response schema defines that type. Mixing payload types on a single stream is not permitted.
 
@@ -51,7 +51,7 @@ An **error frame** signals that the stream has terminated due to an error. Its p
 After a final or error frame, the stream is closed. Sending additional frames after either is a protocol violation.
 
 #### Structured Streams
-Are made up of two different encodings, while using the same framing. (`application/duh-stream+json` and `application/duh-stream+protobuf`) Both content types use length-prefix framing. The payload encoding — JSON or Protobuf — is determined by the content type declared in the `Accept` header of the request. Each frame is structured as follows:
+Are made up of two different encodings, while using the same framing. (`application/duh-stream+json` and `application/duh-stream+protobuf`) Both content types use length-prefix framing. The payload encoding (JSON or Protobuf) is determined by the content type declared in the `Accept` header of the request. Each frame is structured as follows:
 
 ```
 [ 1 byte: flag ][ 4 bytes: unsigned 32-bit big-endian length ][ N bytes: payload ]
@@ -67,11 +67,11 @@ The flag byte values are:
 
 The length field specifies the byte length of the payload that follows. For a final frame with no payload, length MUST be `0`. For an error frame, the payload is a Reply structure encoded in the content type negotiated for the stream.
 
-The `Content-Type` header on the response echoes the content type requested by the client in the `Accept` header: either `application/duh-stream+json` or `application/duh-stream+protobuf`. The client MUST use this value as the authoritative signal for how to decode frame payloads.
+The `Content-Type` header on the response echoes the content type requested by the client in the `Accept` header, either `application/duh-stream+json` or `application/duh-stream+protobuf`. The client MUST use this value as the authoritative signal for how to decode frame payloads.
 
-> The JSON fallback rule from the general spec — where a server that cannot satisfy the requested content type falls back to `application/json` — does **not** apply to streaming endpoints. If the client requests `application/duh-stream+protobuf` and the server does not support it, the server MUST return a `400` with a standard Reply structure. A fallback to `application/duh-stream+json` is not permitted; the client has already committed to a binary encoding and cannot be expected to handle a different stream format.
+> The JSON fallback rule from the general spec (where a server that cannot satisfy the requested content type falls back to `application/json`) does **not** apply to streaming endpoints. If the client requests `application/duh-stream+protobuf` and the server does not support it, the server MUST return a `400` with a standard Reply structure. A fallback to `application/duh-stream+json` is not permitted; the client has already committed to a binary encoding and cannot be expected to handle a different stream format.
 
-A mid-stream disconnection before a final or error frame is an infrastructure error. The client MAY retry from the beginning. Resumption from a specific frame is not supported — if your use case requires it, encode sequence information in your payload type.
+A mid-stream disconnection before a final or error frame is an infrastructure error. The client MAY retry from the beginning. Resumption from a specific frame is not supported; if your use case requires it, encode sequence information in your payload type.
 
 A payload type with a sequence field looks like this:
 ```
@@ -83,7 +83,7 @@ flag=0x0  length=0x00000031
 flag=0x0  length=0x00000032
 {"sequence": 2, "userId": "def", "action": "logout"}
 ```
-On reconnect, the client sends the last received `sequence` value in the request body. The server resumes from that point. The framing layer has no knowledge of this — it is entirely between the client and server application logic.
+On reconnect, the client sends the last received `sequence` value in the request body. The server resumes from that point. The framing layer has no knowledge of this; it is entirely between the client and server application logic.
 
 A final frame carrying an example payload of the same type:
 ```
@@ -97,7 +97,7 @@ A final frame with no payload:
 flag=0x1  length=0x00000000
 ```
 
-An error frame arriving after data frames have already been sent — the client MUST be prepared to receive an error frame at any point in the stream, not just at the start:
+An error frame arriving after data frames have already been sent. The client MUST be prepared to receive an error frame at any point in the stream, not just at the start:
 ```
 // Frame 1: data
 flag=0x0  length=0x00000031
@@ -113,7 +113,7 @@ flag=0x2  length=0x00000045
 SSE and the browser `EventSource` API were considered as the browser streaming transport for DUH-RPC and rejected for two reasons:
 
 - It is limited to GET requests and cannot carry a request body. Stream parameters would need to be passed as query strings, exposing potentially sensitive data in URLs and server logs.
-- SSE was designed for server-push use cases — unsolicited updates from server to browser. DUH-RPC streams are parameterized RPC calls that return multiple values over time. The protocol does not fit the use case.
+- SSE was designed for server-push use cases (unsolicited updates from server to browser). DUH-RPC streams are parameterized RPC calls that return multiple values over time. The protocol does not fit the use case.
 
 Browser clients SHOULD use `application/duh-stream+json` via `fetch()`. The frame parsing required is minimal and keeps the mental model consistent across browser and non-browser clients.
 
@@ -121,6 +121,6 @@ Browser clients SHOULD use `application/duh-stream+json` via `fetch()`. The fram
 
 ### Bidirectional Streams
 
-Bidirectional streaming — where both client and server send frames over the same connection is not yet defined. 
+Bidirectional streaming (where both client and server send frames over the same connection) is not yet defined.
 
 TODO: Define bidirectional streaming semantics. client-to-server frame structure, and half-close behavior.

--- a/docs/why-not-grpc.md
+++ b/docs/why-not-grpc.md
@@ -34,6 +34,19 @@ because gRPC carried more than they needed. When we moved Gubernator from gRPC t
 removed around 2,000 lines of code, some of it written only to manage the connection lifecycle and
 graceful shutdown.
 
+### The framework decides before you do
+
+Some requirements don't fit the shape gRPC chose for you, and you find out only when one arrives. Try
+to upload a multi-megabyte file. You can marshal it into a single protobuf message and fight the
+message-size limits and the memory it takes to hold the whole thing, or you can reach for gRPC
+streaming and take on a second programming model just to move some bytes. Either way the framework
+decided your options before the requirement existed.
+
+Plain HTTP already carries opaque bytes. DUH-RPC keeps structured calls in protobuf or JSON and lets
+unstructured data ride as a content endpoint, where uploading a file is just a POST of the file. The
+transport never forces the shape of your data, so a requirement you didn't foresee doesn't cost you a
+second protocol.
+
 ### Apples to apples
 
 Compare like for like, the same serialization on both sides, and the framework shows up in the

--- a/docs/why-not-rest.md
+++ b/docs/why-not-rest.md
@@ -1,49 +1,96 @@
-I always struggle to write such articles, as I don't really like bashing other techs, so I'll have to come back to this
-later. However...
+# Why not REST?
+REST is a style, not a specification. It tells you to model your API as resources and lean on HTTP's verbs, then it leaves the rest to you. Where do the parameters go? What does an error look like? How do you page through a list?
 
-### REST performance will always be slower than RPC
-The main reason REST will always be slower than GRPC and DUH-RPC is due to REST requiring an HTTP Router for
-matching complex REST paths like `/v1/{thing}/collection/{id}/foo`. Both GRPC and DUH-RPC use simple string matching to
-connect an RPC method to a handler which results in unparalleled performance.
+REST hands you a decision on every endpoint; RPC takes it away. What's left is an API that looks the same everywhere, because there was only ever one way to write it. The rest of this is the long version of that sentence, including the parts REST genuinely gets right.
 
-### The hierarchical nature of REST does not lend itself to clean interfaces over time.
-RPC style APIs do not suffer from the hierarchical structure problems that rest APIs do.
-(TODO: Write a blog post about this and link it here) or if you are at mailgun, read the 'HTTP and GRPC Design Guide'
-in the Mailgun wiki.
+### REST makes you decide the same thing on every endpoint
 
-### Rest calls typically become method calls in code
-Given the notorious pet store example, https://petstore.swagger.io/ clients will typically and inevitably convert
-those REST calls to RPC style method calls.
+Pick any REST API that's been alive a few years and look at how it takes input. You'll find an id in a path on one endpoint, in a query string on the next, and in a JSON body on the third. Not because anyone was careless, but because all three are legal REST, and whoever wrote each one picked what felt right that day.
 
-`GET /pet/findByStatus` becomes `find_pets_by_tags()`
-`POST /pet` becomes `add_pet()`
-`PUT /pet` becomes `update_pet()`
-`DELETE /pet/{petId]` becomes `delete_pet()`
+Now multiply that by every decision REST leaves open. Which verb does an action that isn't quite CRUD use, PUT or POST? Is a not-found a 404 with an empty body, a 404 with `{"error": "..."}`, or a 200 with `{"found": false}`? Does a list page with `?offset=`, `?page=`, a cursor, or a `Link` header? Each question has several correct answers, so different parts of the same API answer them differently.
 
-For machine-to-machine communication, REST offers few benefits over DUH-RPC.
+None of this is a bug. It's the accumulated cost of a style that prizes flexibility over agreement. Every "do it however you like" is something your team now has to decide, document, and remember, on every endpoint, forever.
 
-### REST is stateless and thus cacheable
-This is a semantic that RPC calls should emulate where is makes sense. CRUD operations are a great example of 
-an appropriate use of a stateless API.
+You can fix this by writing the conventions down, putting them in an OpenAPI spec, and running a linter in CI that rejects any endpoint that strays from your guidelines. Plenty of teams do exactly this, and it works; the divergence stops.
 
-### Intermediaries
-Intermediaries can exist between the client and the server. While this is often less useful due to the advent of TLS 
-everywhere, it is still true of RPC methods. Most of the ways in which REST requests can be augmented and mutated is
-via HTTP Headers which are still accessable and should still be utilized when designing and using RPC style API's. 
-The best example of this is using for authZ and authN.
+### Some of those choices are one-way doors
 
-### REST has no standardized response body
-Most REST APIs contrive their own response bodies depending on the experience of the designer and the use case involved.
-This divergence of REST APIs makes it difficult for libraries and frameworks to handle errors uniformly.
+Let's say your spec standardizes on query parameters and form data for all input. It's clean, it's consistent, and your linter enforces it on every endpoint.
 
-However, n effort to standardize REST API error handling is underway, the IETF devised RFC 7807, which creates a 
-generalized error-handling schema.
+Then we need an API to send a deeply nested object, the kind of structure query strings and form encoding were never built to carry. Now you have two bad options. Bolt a JSON body onto that one endpoint and break the convention you spent a year enforcing, or contort the data into a flat shape it doesn't want. The early choice was a one-way door, and you didn't notice until you needed to walk back through it.
 
-* type – a URI identifier that categorizes the error
-* title – a brief, human-readable message about the error
-* status – the HTTP response code (optional)
-* detail – a human-readable explanation of the error
-* instance – a URI that identifies the specific occurrence of the error
+gRPC isn't immune to this; it just has different doors. Try to upload a multi-megabyte file. You can marshal it into a single protobuf message and fight the size limits and the memory, or you can reach for gRPC streaming and take on a whole second programming model to move some bytes. The framework decided your options before the requirement existed.
 
-DUH-RPC takes some of its inspiration from this RFC and from GRPC to implement the `Reply` structure. With the 
-most notable difference being the `detail` as a map of strings which is similar to HTTP headers.
+DUH-RPC doesn't have this failure mode, because it never takes the choice away from you. Structured endpoints carry messages, nested or not, as JSON or protobuf in the body. Content endpoints carry opaque bytes; if you need to upload a file, you POST the file, exactly as the spec describes for unstructured data. Plain HTTP already carries both, so the transport never forces the shape of your data.
+
+That's the real freedom REST and gRPC were each reaching for, and each gave up somewhere. You should never have to design around the framework you chose.
+
+### The hierarchy you pick today is wrong tomorrow
+
+Another issue with REST APIs is that they encode one view of the world, the hierarchy you happened to have the day you designed it.
+
+At Mailgun we built contact lists nested under the domain that owned them, `/v1/accounts/{id}/domains/{domain}/contacts`. It was the obvious shape; a contact list belonged to a domain. Months later product wanted account-wide contact lists, and the obvious shape for those was `/v1/accounts/{id}/contacts`. Now the word "contacts" meant two different things depending on where you stood in the hierarchy, and neither path could be retired.
+
+With a public API the old hierarchy never really goes away, so a "fix" means a second hierarchy standing next to the first, bugs fixed twice and both tested forever.
+
+But wait, REST has an escape for this, and I've recommended it myself. Flatten the hierarchy and push the variable part into a query string, `/v1/contacts?domain=example.com`, so that adding an `account_id` later is a new parameter instead of a re-shaped path. It genuinely helps. But a query string is the dead end from the last section wearing a different hat, and your input is now scattered between the path and the query besides.
+
+See [The RESTful Hierarchy Problem](https://wippler.dev/posts/The-Restful-Hierarchy-Problem).
+
+### The path is the wrong place for data
+
+The path is for routing. The moment you put a user-controlled value in it, you've turned a routing problem into a parsing problem, and you don't own all the parsers.
+
+At Mailgun we had `/v2/domains/{domain}/tags/{tag}`. It worked until someone created a tag named `#trending`. A `#` is legal in a URL, where it marks the start of a fragment, so Flask read `#trending` as an anchor and routed the request as if the tag weren't there at all. The tag was valid. The endpoint was valid. The URL grammar disagreed with both.
+
+The deeper problem is that a request crosses a JavaScript frontend, a proxy, and a backend, three different URL parsers written against the same RFC by people who read it differently. As long as user data sits in the path, you're betting all three agree on every character a customer can type. They don't, and the failures are the worst kind, silent misroutes and security holes rather than clean errors.
+
+You can adapt by normalizing the value and swap the awkward characters, until `2020/02/01` and `2020_02_01` collapse into the same path and your users can't tell two resources apart. Or trade the name for an opaque id and add a second API just to look the id up. Every fix buys back one corner by selling another.
+
+DUH-RPC keeps the path to a fixed `subject.method` that you control end to end, never the customer. Every user-controlled value rides in the body, where a single encoder, JSON or protobuf, handles `#trending` and `2020/02/01` and anything else identically on every hop. The router never sees customer data, so it never has to have an opinion about it.
+
+See [Mastering RESTful Design](https://wippler.dev/posts/Mastering-RESTful-Design).
+
+### REST endpoints become method calls anyway
+
+Open the canonical Swagger pet store and generate a client from its OpenAPI spec. You don't get a tour of resources and verbs; you get a list of methods. `add_pet()`, `find_pets_by_status()`, `update_pet()`, `delete_pet()`. The paths and the HTTP verbs are gone, compiled away into function names.
+
+That isn't the generator being lazy. It's the generator admitting what the API actually is. Nobody writes `http.PUT("/pet")` in application code; they call `update_pet()`, because the operation is the unit a developer thinks in, not the resource and not the verb.
+
+The server side admits it too. The operations that were never CRUD (cancel an order, retry a job, send a message) come out as verb sub-resources, `POST /orders/{id}/cancel`, `POST /jobs/{id}/retry`. Those are RPC calls wearing a REST costume. Both ends of the wire quietly agree the real interface is a set of methods, then spend effort translating to and from a resource model in between.
+
+So REST became a layer in the middle that both sides paid for and neither used. The client generated its way out of it; the server bent its operations around it.
+
+DUH-RPC skips the translation. `/v1/pets.add`, `/v1/pets.findByStatus`, `/v1/orders.cancel`. The wire format and the method call are the same shape, so there's nothing to generate, nothing to keep in sync, and nothing to get wrong between them. For machine-to-machine traffic, that middle layer was the only thing REST was adding, and removing it costs you nothing.
+
+### A router is slower than a switch
+
+Every REST request has to be routed, and routing a REST path is pattern matching. The router holds a set of templates like `/v1/{thing}/collection/{id}/foo`, and for each request it walks them, pulls the variables out of the path, and works out which one matched. The more endpoints you have and the more variables each path carries, the more work that is.
+
+RPC dispatch isn't pattern matching. The path is a fixed string, `/v1/users.create`, and the server looks it up in a map. No variables to extract, no templates to walk, just an exact match to a handler. gRPC works this way and so does DUH-RPC, and it's the cheaper operation by construction.
+
+But be careful what you credit the difference to, because two separate costs usually get blended into one. People say REST is slow and mean JSON; they say gRPC is fast and mean protobuf. Serialization and routing are different things, and most "REST vs gRPC" benchmarks quietly change both at once.
+
+Pull them apart. The router-versus-switch gap is real but small. The JSON-versus-protobuf gap is the bigger lever, and it has nothing to do with REST; it's a serialization choice you can make on either side. DUH-RPC lets you keep protobuf without taking on a framework to get it, which is the whole point. You don't need gRPC to stop paying the JSON tax.
+
+And be honest about the stakes. For most services neither gap is the bottleneck; your database is. Don't choose an API style for the microseconds. But when you genuinely need the headroom, the switch and protobuf are both already there, and you didn't adopt a framework to reach them. The [DUH benchmarks](https://github.com/duh-rpc/duh-benchmarks.go) compare like for like if you want the numbers.
+
+### What REST gets right, and RPC keeps
+
+None of this means REST was a mistake. It got real things right, and a good RPC style keeps them instead of throwing them out with the resource hierarchy.
+
+Statelessness is the big one. A REST request carries everything the server needs to handle it, with no session sitting on the server between calls, and that property is most of what lets REST scale horizontally. DUH keeps it. Every call is self-contained and there's no connection-level state to coordinate.
+
+Caching is the part people get wrong because they file it under REST when it belongs to content delivery. Transparent HTTP caching is a content-delivery property, not an API property. It rides on GET and URL cache keys, and it's how CDNs and browsers serve the images and static assets a UI loads over and over. Your service-to-service calls are dynamic and usually authenticated; you do not want a proxy handing back a stale one, so POST-only costs your API nothing it ever wanted. Where caching actually helps an API, you do it deliberately at the application layer, where you control what's safe to reuse. And where you're shipping cacheable content to a browser, that's a plain GET behind a CDN, which DUH never stops you running alongside your API.
+
+Intermediaries are the second. Proxies, gateways, and load balancers can act on a request without understanding its body, as long as the signals they need live in headers. That's still true under DUH. Authentication and authorization go in headers the way they always did, and DUH adds its own (`X-DUH-Version`, the `X-RPC-` metadata convention) in the same spirit. The body is yours; the headers are the network's.
+
+And the error shape. REST's original sin is that it never had a standard one, the divergence from the first section at its worst; every API invents its own error body and no library can handle them all. But the REST community saw the problem and answered it with RFC 7807, a single `problem+json` schema with `type`, `title`, `status`, `detail`, and `instance`. That instinct is exactly right. DUH's `Reply` takes its inspiration from RFC 7807 and from gRPC's status, with the main difference that `details` is a map of strings, closer to how headers already work.
+
+The goal was never to reject REST wholesale. It was to keep the parts that earned their place (stateless requests, header-driven intermediaries, one error shape) and drop the part that costs the most, the resource hierarchy you have to design around forever.
+
+### RPC has only one shape to offer
+
+REST gives you a hundred good choices and asks you to make every one, on every endpoint, then live with them. Each choice is defensible; the sum is an API that diverges by taste, locks you in by accident, and freezes an org chart you've already outgrown.
+
+RPC makes the choices once. Input in the body, POST, a cursor, a `Reply`, a path that names the method. Consistency isn't something you have to enforce here; the style only has one shape to offer, and nothing left to design around.


### PR DESCRIPTION
### Purpose
The REST-side documentation was a stub full of TODOs, and the wider docs set had
drifted on punctuation and typos. This makes the case for RPC-over-HTTP actually
read-worthy and consistent, and closes the loop with the gRPC reframe (ENG-58) so
the "why not REST" and "why not gRPC" docs rhyme instead of arguing past each other.

What a reader gets out of it:
- `docs/why-not-rest.md` is now a full 8-section essay that walks from REST's
  under-specification through its one-way doors, hierarchy lock-in, and path-as-data
  hazards to what REST gets right and RPC keeps — grounded in real Mailgun war stories.
- `docs/why-not-grpc.md` gains a section showing gRPC has the same "the framework
  decides your options before the requirement exists" failure mode (file upload), and
  how DUH content endpoints avoid it.
- README and the spec now position **Connect (connectrpc.com)** honestly as DUH's
  closest sibling, and call out where it differs (framework + gRPC/gRPC-Web compat
  layer, and no clean unstructured upload/download).

### Implementation
- **`docs/why-not-rest.md`** — full rewrite from stub into an 8-section practitioner
  essay: divergence, one-way doors, hierarchy lock-in, path-as-data, REST-becomes-RPC,
  router-vs-switch, what REST gets right, and a conclusion ("RPC has only one shape to
  offer").
- **`docs/why-not-grpc.md`** — new "The framework decides before you do" section on the
  unstructured upload/download blind spot, mirroring why-not-rest's one-way-doors beat.
- **`README.md` + `docs/spec.md`** — added a Connect sibling note (one-liner in README,
  fuller positioning paragraph in the spec intro cross-linking the Content Endpoints
  section).
- **Docs-wide style cleanup** — across `README.md`, `docs/streaming.md`, `docs/spec.md`,
  `docs/design-guide.md`, `docs/ai-cheatsheet.md`: removed em/en-dashes used as
  punctuation, fixed prose colons, fixed typos.

Fixes ENG-67
