### PR TITLE
Add stream heartbeat for keep-alive and dead-connection detection

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,10 +38,17 @@ type Client struct {
 	// MaxFramePayload is the maximum payload size for streaming frames.
 	// 0 uses DefaultMaxFramePayload.
 	MaxFramePayload int
+	// HeartbeatTimeout is the maximum duration to wait between heartbeat frames
+	// before considering the stream dead. 0 uses DefaultHeartbeatTimeout.
+	// Negative values disable heartbeat enforcement.
+	HeartbeatTimeout time.Duration
 }
 
 // DefaultMaxFramePayload is the default maximum payload size for streaming frames.
 const DefaultMaxFramePayload = 4 * MegaByte
+
+// DefaultHeartbeatTimeout is the default maximum duration to wait between heartbeat frames.
+const DefaultHeartbeatTimeout = 60 * time.Second
 
 const (
 	DetailsHttpCode       = "http.code"
@@ -241,11 +248,17 @@ func (c *Client) DoStream(ctx context.Context, req *http.Request) (StreamReader,
 		maxPayload = DefaultMaxFramePayload
 	}
 
+	heartbeatTimeout := c.HeartbeatTimeout
+	if heartbeatTimeout == 0 {
+		heartbeatTimeout = DefaultHeartbeatTimeout
+	}
+
 	return &streamReader{
-		r:         stream.NewReader(resp.Body, maxPayload),
-		resp:      resp,
-		unmarshal: unmarshalFn,
-		cancel:    cancel,
+		r:                stream.NewReader(resp.Body, maxPayload),
+		resp:             resp,
+		unmarshal:        unmarshalFn,
+		cancel:           cancel,
+		heartbeatTimeout: heartbeatTimeout,
 	}, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -536,7 +536,7 @@ func TestVersionHeaderOnStream(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		duh.HandleStream(w, r, func(r *http.Request, sw duh.StreamWriter) error {
 			return sw.Close(nil)
-		})
+		}, nil)
 	}))
 	defer server.Close()
 

--- a/demo/handler.go
+++ b/demo/handler.go
@@ -50,7 +50,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleRenderPixel(w, r)
 		return
 	case "/v1/events.list":
-		duh.HandleStream(w, r, h.listEvents)
+		duh.HandleStream(w, r, h.listEvents, nil)
 		return
 	case "/v1/bytes.download":
 		h.handleDownloadBytes(w, r)

--- a/docs/features/ENG-75-stream-heartbeat/blueprint.md
+++ b/docs/features/ENG-75-stream-heartbeat/blueprint.md
@@ -1,0 +1,246 @@
+# Stream Heartbeat Blueprint
+
+## Objective
+
+DUH-RPC structured streams have no mechanism to keep idle connections alive through intermediaries, detect half-open TCP connections, or let clients distinguish a dead server from a slow one. Today, all three failures surface as `io.ErrUnexpectedEOF` — indistinguishable from a server crash mid-frame.
+
+This feature adds a heartbeat frame to the streaming wire protocol. The server sends heartbeats automatically; the client silently consumes them and optionally detects their absence as a dead-connection signal.
+
+## Mental Model
+
+A heartbeat is an empty frame the framework sends on behalf of the handler when the stream is idle. The handler never sees it. The client never sees it. It exists purely to keep the bytes flowing so that infrastructure between the two endpoints — proxies, load balancers, firewalls — does not kill the connection for being idle, and so the client can detect when the server has truly gone away.
+
+The handler's view of the world does not change: call `Send` when you have data, call `Close` when you're done. The framework handles the rest.
+
+## Correctness Constraints
+
+### State Invariants
+
+- **Frame ordering**: heartbeat frames never interleave with a partially-written data, final, or error frame. A frame is atomic on the wire — the mutex guarantees this.
+- **Post-close silence**: no heartbeat frame is ever written after a final or error frame. The heartbeat goroutine stops before `Close` returns.
+- **Single writer at a time**: despite two goroutines (handler + heartbeat ticker), only one holds the mutex and writes to the underlying `io.Writer` at any moment.
+
+### Behavioral Constraints
+
+- **Never surface heartbeats to callers**: `StreamReader.Recv` never returns a heartbeat frame to the caller. It consumes them internally and loops to read the next frame.
+- **Never block Send on heartbeat**: acquiring the mutex for a heartbeat write must not delay a `Send` by more than the time to write 5 bytes + flush. Heartbeat frames are zero-payload; the critical section is tiny.
+- **Heartbeat timeout is a distinct error**: when the client detects a heartbeat timeout, it returns a distinguishable error — not `io.ErrUnexpectedEOF`, not `io.EOF`. Callers can programmatically tell "the connection went silent" apart from "the server crashed mid-frame" or "the stream ended normally."
+
+## Acceptance Criteria
+
+- A stream that sends no data for 60 seconds survives through a proxy with a 60-second idle timeout (heartbeats keep it alive at 30-second intervals).
+- A client connected to a server that silently dies receives a heartbeat timeout error within 60 seconds (2x heartbeat interval), not minutes later via TCP timeout.
+- Existing handler *logic* (no `StreamConfig`, no awareness of heartbeats) works unchanged — heartbeats are sent automatically with defaults. Call sites must add `nil` as the fourth argument to `HandleStream`.
+- `HandleStream` with `&StreamConfig{HeartbeatInterval: -1}` sends no heartbeat frames.
+- Client with `HeartbeatTimeout: -1` never times out on missing heartbeats.
+- The `Recv` loop in every existing client works unchanged — heartbeat frames are invisible.
+
+## Scope
+
+### In Scope
+
+- `FlagHeartbeat` (`0x3`) wire format addition to the streaming spec
+- Automatic server-side heartbeat sending (30s default, configurable via `StreamConfig`)
+- Client-side silent consumption of heartbeat frames in `Recv`
+- Client-side heartbeat timeout detection (60s default, configurable via `Client.HeartbeatTimeout`)
+- New `ErrHeartbeatTimeout` error type distinguishable from `io.ErrUnexpectedEOF`
+- Spec update to `docs/streaming.md` — match the existing spec's voice: direct, RFC-style (MUST/SHOULD/MAY), explains the *why* behind each rule, uses concrete wire-format examples with hex flag values and JSON payloads
+
+### Out of Scope / Non-Goals
+
+- Heartbeats for unstructured streams (`application/octet-stream`) — no framing layer to carry them
+- Bidirectional heartbeats (client-to-server pings) — server-initiated only
+- Automatic reconnection or retry on heartbeat timeout — the caller owns retry policy
+- Heartbeats for bidirectional streaming — bidirectional is not yet defined in the spec
+
+---
+
+## Functional
+
+### Wire Format
+
+The existing frame header is unchanged:
+
+```
+[ 1 byte: flag ][ 4 bytes: uint32 big-endian length ][ N bytes: payload ]
+```
+
+New flag value:
+
+| Flag | Value | Payload | Meaning |
+|------|-------|---------|---------|
+| `FlagData` | `0x0` | message bytes | Data frame |
+| `FlagFinal` | `0x1` | optional message bytes | Clean end of stream |
+| `FlagError` | `0x2` | `Reply` bytes | Error termination |
+| `FlagHeartbeat` | `0x3` | empty (length = 0) | Keep-alive signal |
+
+A heartbeat frame is always exactly 5 bytes on the wire: `[0x03][0x00][0x00][0x00][0x00]`.
+
+Receivers MUST ignore the payload of a heartbeat frame (if any future version adds one). Receivers that encounter an unknown flag value SHOULD skip the frame (read and discard the payload bytes indicated by the length field) rather than treating it as an error — this is existing behavior since `stream.Reader.ReadFrame` returns the raw flag to the caller.
+
+### Server Behavior
+
+When `HandleStream` is called, the framework:
+
+1. Starts a background goroutine with a `time.Ticker` at the configured heartbeat interval (default 30s).
+2. The ticker goroutine acquires `streamWriter.mu`, writes a `FlagHeartbeat` frame with zero-length payload, flushes, and releases the lock.
+3. When `Close` is called (or the handler returns an error), the framework signals the heartbeat goroutine to stop via a `stop` channel and waits for it to exit before writing the final/error frame.
+4. If `HeartbeatInterval` is negative, no heartbeat goroutine is started.
+5. If `HeartbeatInterval` is zero, the default (30s) is used.
+
+### Client Behavior
+
+When `DoStream` returns a `StreamReader`:
+
+1. `Recv` reads frames in a loop. If it encounters `FlagHeartbeat`, it resets the heartbeat deadline and continues to the next frame — the caller never sees it.
+2. If `HeartbeatTimeout` is positive (default 60s), the client sets a read deadline on each `Recv` call. If no frame (of any kind) arrives within the timeout, `Recv` returns `ErrHeartbeatTimeout`.
+3. If `HeartbeatTimeout` is negative, no timeout is enforced.
+4. If `HeartbeatTimeout` is zero, the default (60s) is used.
+5. Every received frame (data, final, error, or heartbeat) resets the timeout clock.
+
+### Error Type
+
+```go
+var ErrHeartbeatTimeout = errors.New("stream heartbeat timeout: no frames received within deadline")
+```
+
+This is a sentinel error. Callers can check it with `errors.Is(err, duh.ErrHeartbeatTimeout)`.
+
+## Architecture
+
+### Server-Side `streamWriter` Changes
+
+The `streamWriter` struct gains three fields:
+
+```go
+type streamWriter struct {
+	mu      sync.Mutex
+	w       *stream.Writer
+	flusher http.Flusher
+	marshal marshalFunc
+	closed  bool
+	ctx     context.Context
+	stop    chan struct{}
+	stopped chan struct{}
+}
+```
+
+- `mu` protects all writes to `w` and `flusher`, and guards the `closed` flag.
+- `stop` is closed by `Close` (or the error path in `HandleStream`) to signal the heartbeat goroutine.
+- `stopped` is closed by the heartbeat goroutine when it exits; `Close` waits on it to ensure no heartbeat races with the final/error frame.
+
+`Send` and `Close` acquire `mu`. `Close` additionally closes `stop` and waits on `stopped` before writing the final frame under the lock.
+
+### `HandleStream` Changes
+
+```go
+func HandleStream(w http.ResponseWriter, r *http.Request,
+    handler func(*http.Request, StreamWriter) error, conf *StreamConfig)
+```
+
+The fourth parameter is `*StreamConfig`. `nil` means all defaults. This is a mechanical breaking change. All callers must add `nil` as the fourth argument; no handler body changes are required.
+
+```go
+type StreamConfig struct {
+	HeartbeatInterval time.Duration
+}
+```
+
+`HandleStream` resolves the interval (zero → 30s, negative → disabled), constructs `streamWriter`, starts the heartbeat goroutine (if enabled), calls the handler, then cleans up.
+
+### Client-Side `streamReader` Changes
+
+The `streamReader` struct gains a `heartbeatTimeout` field:
+
+```go
+type streamReader struct {
+	r              *stream.Reader
+	resp           *http.Response
+	unmarshal      unmarshalFunc
+	cancel         context.CancelFunc
+	done           bool
+	hasPending     bool
+	heartbeatTimeout time.Duration
+}
+```
+
+The `Recv` method changes:
+
+1. Before reading, if `heartbeatTimeout > 0`, start a `time.AfterFunc` that calls `sr.cancel()` after the timeout duration. This is transport-agnostic — it works for both HTTP/1.1 and HTTP/2 without reaching into the underlying connection.
+2. Read a frame. If the read succeeds, stop the timer. If `FlagHeartbeat`, loop back to step 1 (reset timer, read again).
+3. If the timer fires and cancels the context, `ReadFrame` returns an error. `Recv` translates this to `ErrHeartbeatTimeout`.
+
+### `Client` Struct Changes
+
+```go
+type Client struct {
+	Client           *http.Client
+	MaxFramePayload  int
+	HeartbeatTimeout time.Duration
+}
+```
+
+`DoStream` passes `HeartbeatTimeout` to the `streamReader` it constructs (zero → 60s, negative → disabled).
+
+### `stream` Package — No Changes
+
+`stream.Writer.WriteFrame` and `stream.Reader.ReadFrame` already handle arbitrary flag values. The `FlagHeartbeat` constant is added to `stream/stream.go` for convenience, but the reader/writer logic is unchanged.
+
+## Data Design
+
+No persistent data. All state is in-memory for the duration of a single stream.
+
+### Invariant Preservation
+
+| Invariant | Operations that touch it | Preservation mechanism |
+|---|---|---|
+| Frame ordering | `Send`, `Close`, heartbeat tick | `sync.Mutex` — only one goroutine writes at a time |
+| Post-close silence | `Close`, heartbeat tick | `Close` closes `stop` channel and waits on `stopped` channel before writing final frame. Heartbeat goroutine checks `stop` in its select and exits. |
+| Single writer | `Send`, `Close`, heartbeat tick | `sync.Mutex` on `streamWriter` |
+
+### Illegal State Analysis
+
+- **Heartbeat after close**: structurally prevented — `Close` waits for the heartbeat goroutine to exit (`<-stopped`) before writing the final frame. The goroutine cannot write after `stopped` is closed.
+- **Concurrent frame writes**: structurally prevented by `sync.Mutex`. Two goroutines cannot hold the lock simultaneously.
+- **Client receiving heartbeat**: prevented by application logic — `Recv` loops on heartbeat frames. This relies on correct code, not structural enforcement; the frame type check in `Recv` is the enforcement point.
+
+## Testing
+
+Testing follows the `surface-testing` skill.
+
+### Key Surfaces
+
+- **Integration (server + client over httptest)**: the primary surface. All heartbeat behavior is tested through the existing `httptest.NewServer` + `test.Client` pattern in `functional_test.go`.
+- **Unit (stream package)**: round-trip tests for the new `FlagHeartbeat` constant — write a heartbeat frame, read it back, confirm flag and zero-length payload.
+
+### Test Cases
+
+**Server-side automatic heartbeats:**
+- Stream with a slow handler (sleeps > heartbeat interval) — client receives data frames with heartbeat frames interspersed; client `Recv` only returns data frames.
+- Stream with `HeartbeatInterval: -1` — no heartbeat frames sent.
+- Stream with custom interval — heartbeat frames arrive at the configured cadence.
+
+**Client-side heartbeat timeout:**
+- Server sends one data frame then goes silent (no close, no heartbeat) — client `Recv` returns `ErrHeartbeatTimeout` after the timeout period.
+- Server sends heartbeats but no data — client does not timeout (heartbeats reset the clock); client blocks in `Recv` until data or close arrives.
+- Client with `HeartbeatTimeout: -1` — no timeout, blocks until TCP timeout or context cancel.
+
+**Concurrency correctness:**
+- Rapid `Send` calls interleaved with heartbeat ticks — no panics, no corrupted frames, no interleaved bytes. Verified by reading all frames on the client and confirming each is well-formed.
+
+**Backward compatibility:**
+- Existing tests pass unchanged (with `nil` config parameter added to `HandleStream` calls).
+
+### Fakes / Substitutes
+
+- **Slow handler**: `time.Sleep` inside a handler function to force heartbeat ticks between sends.
+- **Silent server**: handler that sends one frame then blocks on a channel (simulating a hang), allowing the client timeout to fire. The channel is released in test cleanup.
+- **Time**: real `time.Ticker` and `time.AfterFunc` — intervals are short in tests (e.g., 50ms heartbeat, 150ms timeout). No injectable clock needed; the intervals are configurable via `StreamConfig` and `Client.HeartbeatTimeout`.
+
+## Limitations & Future Work
+- **Bidirectional heartbeats**: if bidirectional streaming is added later, the client may also need to send heartbeats to the server. The `FlagHeartbeat` frame type is ready for this — the server reader would silently consume them the same way the client does.
+- **Heartbeat interval negotiation**: the client currently has no way to know the server's heartbeat interval. The client timeout is configured independently. A future enhancement could include the interval in the response headers (e.g., `X-DUH-Heartbeat-Interval: 30`), but for now the 2x-interval default is a safe convention.
+
+## Open Questions
+
+None.

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -1,0 +1,6 @@
+# Repository Registry
+
+| Repo | GitHub |
+|------|--------|
+| duh.go | duh-rpc/duh.go |
+| duh-cli | duh-rpc/duh-cli |

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -39,6 +39,7 @@ Every frame has one of three meanings:
 | Data frame | `0x0` |
 | Final frame | `0x1` |
 | Error frame | `0x2` |
+| Heartbeat frame | `0x3` |
 
 A **data frame** carries a single instance of the stream's payload type.
 
@@ -46,9 +47,11 @@ A **final frame** signals a clean end of stream. It MAY carry a payload of the s
 
 An **error frame** signals that the stream has terminated due to an error. Its payload is always a standard Reply structure, encoded in the stream's content type. After sending an error frame the server MUST close the stream. The client MUST NOT expect further frames.
 
-> The error frame is the one exception to the single payload type rule. It is distinguishable by its flag or event name, so there is no ambiguity.
+A **heartbeat frame** is a keep-alive signal sent by the server when the stream is idle. Its payload MUST be empty (length `0`), making it exactly 5 bytes on the wire: `[0x03][0x00][0x00][0x00][0x00]`. The handler never sends heartbeat frames directly; the framework sends them automatically. Clients MUST silently consume heartbeat frames — they MUST NOT be surfaced to application code.
 
-After a final or error frame, the stream is closed. Sending additional frames after either is a protocol violation.
+> The error frame and heartbeat frame are exceptions to the single payload type rule. They are distinguishable by their flag values, so there is no ambiguity.
+
+After a final or error frame, the stream is closed. Sending additional frames after either is a protocol violation. Heartbeat frames MUST NOT be sent after a final or error frame.
 
 #### Structured Streams
 Are made up of two different encodings, while using the same framing. (`application/duh-stream+json` and `application/duh-stream+protobuf`) Both content types use length-prefix framing. The payload encoding (JSON or Protobuf) is determined by the content type declared in the `Accept` header of the request. Each frame is structured as follows:
@@ -64,14 +67,54 @@ The flag byte values are:
 | `0x0` | Data frame |
 | `0x1` | Final frame |
 | `0x2` | Error frame |
+| `0x3` | Heartbeat frame |
 
-The length field specifies the byte length of the payload that follows. For a final frame with no payload, length MUST be `0`. For an error frame, the payload is a Reply structure encoded in the content type negotiated for the stream.
+The length field specifies the byte length of the payload that follows. For a final frame with no payload, length MUST be `0`. For an error frame, the payload is a Reply structure encoded in the content type negotiated for the stream. For a heartbeat frame, length MUST be `0`.
+
+Receivers that encounter an unknown flag value SHOULD skip the frame (read and discard the payload bytes indicated by the length field) rather than treating it as an error. This allows future flag values to be added without breaking existing clients.
 
 The `Content-Type` header on the response echoes the content type requested by the client in the `Accept` header, either `application/duh-stream+json` or `application/duh-stream+protobuf`. The client MUST use this value as the authoritative signal for how to decode frame payloads.
 
 > The JSON fallback rule from the general spec (where a server that cannot satisfy the requested content type falls back to `application/json`) does **not** apply to streaming endpoints. If the client requests `application/duh-stream+protobuf` and the server does not support it, the server MUST return a `400` with a standard Reply structure. A fallback to `application/duh-stream+json` is not permitted; the client has already committed to a binary encoding and cannot be expected to handle a different stream format.
 
 A mid-stream disconnection before a final or error frame is an infrastructure error. The client MAY retry from the beginning. Resumption from a specific frame is not supported; if your use case requires it, encode sequence information in your payload type.
+
+#### Heartbeats
+
+Structured streams support server-initiated heartbeats to keep idle connections alive through intermediaries (proxies, load balancers, firewalls) and to let clients detect half-open TCP connections.
+
+**Server behavior.** The server SHOULD send heartbeat frames at a regular interval when the stream is idle. The default interval is 30 seconds. The server MAY configure a different interval via `StreamConfig.HeartbeatInterval`. A negative interval disables heartbeats entirely; a zero value uses the default.
+
+Heartbeat frames are sent by a background goroutine that shares a mutex with `Send` and `Close`. A heartbeat frame never interleaves with a partially-written data, final, or error frame. When `Close` is called (or the handler returns an error), the heartbeat goroutine is stopped before the final or error frame is written.
+
+**Client behavior.** The client MUST silently consume heartbeat frames. When `Recv` encounters a heartbeat frame, it resets its internal deadline and reads the next frame — the caller never sees the heartbeat.
+
+If the client has a heartbeat timeout configured (default 60 seconds), it starts a timer before each `ReadFrame` call. If no frame of any kind arrives within the timeout, `Recv` returns `ErrHeartbeatTimeout` — a sentinel error distinct from `io.ErrUnexpectedEOF` and `io.EOF`. Every received frame (data, final, error, or heartbeat) resets the timeout clock. A negative timeout disables enforcement; a zero value uses the default.
+
+The heartbeat timeout SHOULD be at least 2× the server's heartbeat interval. The client has no protocol-level mechanism to discover the server's interval; the 2× convention is a safe default.
+
+A heartbeat frame on the wire:
+```
+// Heartbeat (5 bytes total, no payload)
+flag=0x3  length=0x00000000
+```
+
+Heartbeat frames interspersed with data frames — the client sees only the data frames:
+```
+// Frame 1: data
+flag=0x0  length=0x00000031
+{"sequence": 1, "userId": "abc", "action": "login"}
+
+// Heartbeat (invisible to client)
+flag=0x3  length=0x00000000
+
+// Frame 2: data
+flag=0x0  length=0x00000032
+{"sequence": 2, "userId": "def", "action": "logout"}
+
+// Final
+flag=0x1  length=0x00000000
+```
 
 A payload type with a sequence field looks like this:
 ```

--- a/functional_test.go
+++ b/functional_test.go
@@ -229,7 +229,7 @@ func TestStreamingSendAfterClose(t *testing.T) {
 			// Attempt to Send after Close -- should fail
 			sendErr <- sw.Send(&test.StreamItem{Sequence: 1, Data: "after-close"})
 			return nil
-		})
+		}, nil)
 	})
 
 	server := httptest.NewServer(handler)
@@ -319,7 +319,7 @@ func TestStreamingContextCancel(t *testing.T) {
 				}
 			}
 			return sw.Close(nil)
-		})
+		}, nil)
 	})
 
 	server := httptest.NewServer(handler)
@@ -649,6 +649,269 @@ func TestContentDownloadNotFound(t *testing.T) {
 	require.ErrorAs(t, err, &ce)
 	assert.Equal(t, duh.CodeNotFound, ce.HTTPCode())
 	assert.False(t, ce.IsInfraError())
+}
+
+func TestStreamHeartbeatKeepsAlive(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleStream(w, r, func(r *http.Request, sw duh.StreamWriter) error {
+			for i := 0; i < 3; i++ {
+				if err := sw.Send(&test.StreamItem{Sequence: int64(i), Data: fmt.Sprintf("item-%d", i)}); err != nil {
+					return err
+				}
+				time.Sleep(80 * time.Millisecond)
+			}
+			return sw.Close(nil)
+		}, &duh.StreamConfig{HeartbeatInterval: 50 * time.Millisecond})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	var items []*test.StreamItem
+	for {
+		var item test.StreamItem
+		err := sr.Recv(&item)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		items = append(items, &item)
+	}
+
+	require.Len(t, items, 3)
+	for i, item := range items {
+		assert.Equal(t, int64(i), item.Sequence)
+		assert.Equal(t, fmt.Sprintf("item-%d", i), item.Data)
+	}
+
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamHeartbeatDisabled(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleStream(w, r, func(r *http.Request, sw duh.StreamWriter) error {
+			for i := 0; i < 3; i++ {
+				if err := sw.Send(&test.StreamItem{Sequence: int64(i), Data: fmt.Sprintf("item-%d", i)}); err != nil {
+					return err
+				}
+			}
+			return sw.Close(nil)
+		}, &duh.StreamConfig{HeartbeatInterval: -1})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	var items []*test.StreamItem
+	for {
+		var item test.StreamItem
+		err := sr.Recv(&item)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		items = append(items, &item)
+	}
+
+	require.Len(t, items, 3)
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamHeartbeatTimeout(t *testing.T) {
+	unblock := make(chan struct{})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", duh.ContentStreamJSON)
+		w.Header().Set(duh.HeaderDUHVersion, duh.DUHVersion)
+		w.WriteHeader(http.StatusOK)
+
+		sw := stream.NewWriter(w)
+		payload, _ := json.Marshal(&test.StreamItem{Sequence: 0, Data: "first"})
+		_ = sw.WriteFrame(stream.FlagData, payload)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		// Block until test cleanup
+		<-unblock
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	defer close(unblock)
+
+	c := &duh.Client{Client: &http.Client{}, HeartbeatTimeout: 150 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	var item test.StreamItem
+	require.NoError(t, sr.Recv(&item))
+	assert.Equal(t, int64(0), item.Sequence)
+	assert.Equal(t, "first", item.Data)
+
+	err = sr.Recv(&item)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, duh.ErrHeartbeatTimeout))
+
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamHeartbeatTimeoutDisabled(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", duh.ContentStreamJSON)
+		w.Header().Set(duh.HeaderDUHVersion, duh.DUHVersion)
+		w.WriteHeader(http.StatusOK)
+
+		sw := stream.NewWriter(w)
+		payload, _ := json.Marshal(&test.StreamItem{Sequence: 0, Data: "only"})
+		_ = sw.WriteFrame(stream.FlagData, payload)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		_ = sw.WriteFrame(stream.FlagFinal, nil)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}, HeartbeatTimeout: -1}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	var item test.StreamItem
+	require.NoError(t, sr.Recv(&item))
+	assert.Equal(t, int64(0), item.Sequence)
+
+	err = sr.Recv(&item)
+	assert.Equal(t, io.EOF, err)
+
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamHeartbeatTimeoutResetByHeartbeat(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleStream(w, r, func(r *http.Request, sw duh.StreamWriter) error {
+			time.Sleep(300 * time.Millisecond)
+			if err := sw.Send(&test.StreamItem{Sequence: 0, Data: "after-wait"}); err != nil {
+				return err
+			}
+			return sw.Close(nil)
+		}, &duh.StreamConfig{HeartbeatInterval: 50 * time.Millisecond})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}, HeartbeatTimeout: 150 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	var item test.StreamItem
+	require.NoError(t, sr.Recv(&item))
+	assert.Equal(t, int64(0), item.Sequence)
+	assert.Equal(t, "after-wait", item.Data)
+
+	err = sr.Recv(&item)
+	assert.Equal(t, io.EOF, err)
+
+	require.NoError(t, sr.Close())
+}
+
+func TestStreamHeartbeatConcurrency(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleStream(w, r, func(r *http.Request, sw duh.StreamWriter) error {
+			for i := 0; i < 50; i++ {
+				if err := sw.Send(&test.StreamItem{Sequence: int64(i), Data: fmt.Sprintf("item-%d", i)}); err != nil {
+					return err
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+			return sw.Close(nil)
+		}, &duh.StreamConfig{HeartbeatInterval: 10 * time.Millisecond})
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	c := &duh.Client{Client: &http.Client{}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/test.stream", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentStreamJSON)
+
+	sr, err := c.DoStream(ctx, req)
+	require.NoError(t, err)
+
+	var items []*test.StreamItem
+	for {
+		var item test.StreamItem
+		err := sr.Recv(&item)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		items = append(items, &item)
+	}
+
+	require.Len(t, items, 50)
+	for i, item := range items {
+		assert.Equal(t, int64(i), item.Sequence)
+	}
+
+	require.NoError(t, sr.Close())
 }
 
 // TODO: Update the benchmark tests

--- a/internal/test/handler.go
+++ b/internal/test/handler.go
@@ -34,7 +34,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleTestErrors(w, r)
 		return
 	case "/v1/test.stream":
-		duh.HandleStream(w, r, h.handleTestStream)
+		duh.HandleStream(w, r, h.handleTestStream, nil)
 		return
 	}
 	duh.ReplyWithCode(w, r, duh.CodeNotImplemented, nil, "no such method; "+r.URL.Path)

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	FlagData  byte = 0x0
-	FlagFinal byte = 0x1
-	FlagError byte = 0x2
+	FlagData      byte = 0x0
+	FlagFinal     byte = 0x1
+	FlagError     byte = 0x2
+	FlagHeartbeat byte = 0x3
 )
 
 // headerSize is the size of a frame header: 1 byte flag + 4 bytes uint32 length.

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -86,6 +86,18 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	assert.Equal(t, large, payload)
 }
 
+func TestHeartbeatFrameRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	r := stream.NewReader(&buf, 0)
+
+	require.NoError(t, w.WriteFrame(stream.FlagHeartbeat, nil))
+	flag, payload, err := r.ReadFrame()
+	require.NoError(t, err)
+	assert.Equal(t, stream.FlagHeartbeat, flag)
+	assert.Nil(t, payload)
+}
+
 func TestReadFrameErrors(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/streaming.go
+++ b/streaming.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
+	"time"
 
 	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
 	"github.com/duh-rpc/duh.go/v2/stream"
@@ -46,17 +48,30 @@ type StreamWriter interface {
 var _ StreamWriter = (*streamWriter)(nil)
 
 type streamWriter struct {
+	mu      sync.Mutex
 	w       *stream.Writer
 	flusher http.Flusher
 	marshal func(proto.Message) ([]byte, error)
 	ctx     context.Context
 	closed  bool
+	stop    chan struct{}
+	stopped chan struct{}
 }
 
 // ErrStreamClosed is returned when Send or Close is called on a closed StreamWriter.
 var ErrStreamClosed = errors.New("stream is closed")
 
+var ErrHeartbeatTimeout = errors.New("stream heartbeat timeout: no frames received within deadline")
+
+type StreamConfig struct {
+	HeartbeatInterval time.Duration
+}
+
+const DefaultHeartbeatInterval = 30 * time.Second
+
 func (sw *streamWriter) Send(msg proto.Message) error {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
 	if sw.closed {
 		return ErrStreamClosed
 	}
@@ -74,6 +89,11 @@ func (sw *streamWriter) Send(msg proto.Message) error {
 }
 
 func (sw *streamWriter) Close(msg proto.Message) error {
+	close(sw.stop)
+	<-sw.stopped
+
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
 	if sw.closed {
 		return ErrStreamClosed
 	}
@@ -101,7 +121,7 @@ func (sw *streamWriter) Context() context.Context {
 
 // HandleStream validates the Accept header, asserts http.Flusher, constructs a
 // StreamWriter, calls the handler, and handles error frames on handler failure.
-func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Request, StreamWriter) error) {
+func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Request, StreamWriter) error, conf *StreamConfig) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		ReplyWithCode(w, r, CodeInternalError, nil, "response writer does not support streaming")
@@ -132,12 +152,50 @@ func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Req
 		flusher: flusher,
 		marshal: marshalFn,
 		ctx:     r.Context(),
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+
+	interval := DefaultHeartbeatInterval
+	if conf != nil && conf.HeartbeatInterval != 0 {
+		interval = conf.HeartbeatInterval
+	}
+
+	if interval > 0 {
+		go func() {
+			defer close(sw.stopped)
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-sw.stop:
+					return
+				case <-ticker.C:
+					sw.mu.Lock()
+					if sw.closed {
+						sw.mu.Unlock()
+						return
+					}
+					_ = sw.w.WriteFrame(stream.FlagHeartbeat, nil)
+					sw.flusher.Flush()
+					sw.mu.Unlock()
+				}
+			}
+		}()
+	} else {
+		close(sw.stopped)
 	}
 
 	err := handler(r, sw)
 	if err == nil || sw.closed {
 		return
 	}
+
+	close(sw.stop)
+	<-sw.stopped
+
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
 
 	reply := buildErrorReply(err)
 	payload, marshalErr := sw.marshal(reply)
@@ -177,12 +235,13 @@ type StreamReader interface {
 var _ StreamReader = (*streamReader)(nil)
 
 type streamReader struct {
-	r          *stream.Reader
-	resp       *http.Response
-	unmarshal  func([]byte, proto.Message) error
-	cancel     context.CancelFunc
-	done       bool
-	hasPending bool
+	r                *stream.Reader
+	resp             *http.Response
+	unmarshal        func([]byte, proto.Message) error
+	cancel           context.CancelFunc
+	done             bool
+	hasPending       bool
+	heartbeatTimeout time.Duration
 }
 
 func (sr *streamReader) Recv(msg proto.Message) error {
@@ -190,61 +249,78 @@ func (sr *streamReader) Recv(msg proto.Message) error {
 		return io.EOF
 	}
 
-	// If a previous call read a final frame with payload, the payload was already
-	// unmarshalled. This call returns EOF to signal stream completion.
 	if sr.hasPending {
 		sr.hasPending = false
 		sr.done = true
 		return io.EOF
 	}
 
-	flag, payload, err := sr.r.ReadFrame()
-	if err != nil {
-		if err == io.EOF {
-			// Stream ended without a final or error frame -- infrastructure error per spec.
-			sr.done = true
-			return io.ErrUnexpectedEOF
+	for {
+		var timer *time.Timer
+		if sr.heartbeatTimeout > 0 {
+			timer = time.AfterFunc(sr.heartbeatTimeout, func() {
+				sr.cancel()
+			})
 		}
-		sr.done = true
-		return err
-	}
 
-	switch flag {
-	case stream.FlagData:
-		if err := sr.unmarshal(payload, msg); err != nil {
+		flag, payload, err := sr.r.ReadFrame()
+
+		if timer != nil {
+			timer.Stop()
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				sr.done = true
+				return io.ErrUnexpectedEOF
+			}
 			sr.done = true
+			if sr.heartbeatTimeout > 0 && sr.resp.Request != nil && sr.resp.Request.Context().Err() != nil {
+				return ErrHeartbeatTimeout
+			}
 			return err
 		}
-		return nil
 
-	case stream.FlagFinal:
-		if len(payload) > 0 {
+		switch flag {
+		case stream.FlagHeartbeat:
+			continue
+
+		case stream.FlagData:
 			if err := sr.unmarshal(payload, msg); err != nil {
 				sr.done = true
 				return err
 			}
-			sr.hasPending = true
 			return nil
-		}
-		sr.done = true
-		return io.EOF
 
-	case stream.FlagError:
-		sr.done = true
-		var reply v1.Reply
-		if err := sr.unmarshal(payload, &reply); err != nil {
-			return fmt.Errorf("while unmarshalling error frame: %w", err)
-		}
-		return &ClientError{
-			code:     reply.Code,
-			httpCode: sr.resp.StatusCode,
-			msg:      reply.Message,
-			details:  reply.Details,
-		}
+		case stream.FlagFinal:
+			if len(payload) > 0 {
+				if err := sr.unmarshal(payload, msg); err != nil {
+					sr.done = true
+					return err
+				}
+				sr.hasPending = true
+				return nil
+			}
+			sr.done = true
+			return io.EOF
 
-	default:
-		sr.done = true
-		return fmt.Errorf("unknown frame flag: 0x%x", flag)
+		case stream.FlagError:
+			sr.done = true
+			var reply v1.Reply
+			if err := sr.unmarshal(payload, &reply); err != nil {
+				return fmt.Errorf("while unmarshalling error frame: %w", err)
+			}
+			return &ClientError{
+				code:     reply.Code,
+				httpCode: sr.resp.StatusCode,
+				msg:      reply.Message,
+				details:  reply.Details,
+			}
+
+		default:
+			sr.done = true
+			return fmt.Errorf("unknown frame flag: 0x%x", flag)
+		}
 	}
 }
 


### PR DESCRIPTION
### Purpose

Structured streams had no mechanism to keep idle connections alive through intermediaries (proxies, load balancers, firewalls) or detect half-open TCP connections. All three failure modes surfaced as `io.ErrUnexpectedEOF` — indistinguishable from a server crash mid-frame.

This adds a heartbeat frame to the streaming wire protocol. The server sends heartbeats automatically when the stream is idle (default 30s); the client silently consumes them and optionally detects their absence as a dead-connection signal via `ErrHeartbeatTimeout` (default 60s).

**New API surface:**
- `stream.FlagHeartbeat` (`0x3`) — new wire frame type
- `duh.StreamConfig{HeartbeatInterval}` — server-side configuration (negative disables, zero uses 30s default)
- `duh.Client.HeartbeatTimeout` — client-side timeout (negative disables, zero uses 60s default)
- `duh.ErrHeartbeatTimeout` — sentinel error for `errors.Is` checks
- `duh.HandleStream` now takes `*StreamConfig` as 4th parameter (`nil` for defaults)

**Usage example:**
```go
// Server: custom 10s heartbeat interval
duh.HandleStream(w, r, handler, &duh.StreamConfig{
    HeartbeatInterval: 10 * time.Second,
})

// Client: detect dead connections within 20s
c := &duh.Client{
    Client:           httpClient,
    HeartbeatTimeout: 20 * time.Second,
}
```

Existing handler logic is unchanged — heartbeats are fully transparent to both handler code and client `Recv` loops. The only mechanical change is adding `nil` as the fourth argument to `HandleStream` call sites.

### Implementation

- **`stream/stream.go`**: Added `FlagHeartbeat byte = 0x3` constant
- **`streaming.go` (server)**: `streamWriter` gains `sync.Mutex`, `stop`/`stopped` channels. A background goroutine sends heartbeat frames at the configured interval. `Close` stops the goroutine before writing the final frame. `Send` acquires the mutex to prevent interleaving. Added `StreamConfig`, `DefaultHeartbeatInterval`, `ErrHeartbeatTimeout`
- **`streaming.go` (client)**: `streamReader.Recv` silently consumes heartbeat frames in a loop. Uses `time.AfterFunc` + context cancellation for transport-agnostic timeout detection (works for both HTTP/1.1 and HTTP/2)
- **`client.go`**: `Client.HeartbeatTimeout` field, `DefaultHeartbeatTimeout` constant, timeout resolution in `DoStream`
- **Callers**: All 5 `HandleStream` call sites updated with `nil` config
- **`docs/streaming.md`**: Spec updated with heartbeat frame semantics, wire format, server/client behavior, and examples
- **Tests**: 7 new tests — heartbeat round-trip, keep-alive, disabled, timeout, timeout-disabled, timeout-reset-by-heartbeat, concurrency (50 items + 10ms heartbeat with `-race`)

Fixes ENG-75