### PR TITLE
Add HandleBytes for unstructured octet-stream responses

### DIFF
--- a/bytes_writer_test.go
+++ b/bytes_writer_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 Derrick J Wippler
+
+Licensed under the MIT License, you may obtain a copy of the License at
+
+https://opensource.org/license/mit/ or in the root of this code repo
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duh_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/duh-rpc/duh.go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleBytesStreamsBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			_, err := bw.Write([]byte("hello, bytes"))
+			return err
+		})
+	}))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL, "", nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "hello, bytes", string(body))
+	assert.Equal(t, duh.ContentOctetStream, resp.Header.Get("Content-Type"))
+	assert.Equal(t, duh.DUHVersion, resp.Header.Get(duh.HeaderDUHVersion))
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+}
+
+func TestHandleBytesHandlerOverridesHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			// Override the seeded Content-Type and set an app header before writing.
+			bw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			bw.Header().Set("X-RPC-Job-Id", "job-42")
+			_, err := bw.Write([]byte("output"))
+			return err
+		})
+	}))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL, "", nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "output", string(body))
+	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "job-42", resp.Header.Get("X-RPC-Job-Id"))
+}
+
+func TestHandleBytesErrorBeforeFirstByte(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			// The handler fails before producing any output, so HandleBytes can still
+			// send a standard error Reply.
+			return duh.NewServiceError(duh.CodeBadRequest, "bad input", nil, nil)
+		})
+	}))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL, "", nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, duh.DUHVersion, resp.Header.Get(duh.HeaderDUHVersion))
+	assert.NotEqual(t, duh.ContentOctetStream, resp.Header.Get("Content-Type"))
+	assert.Contains(t, string(body), "bad input")
+}
+
+func TestHandleBytesErrorAfterFirstByteIsCommitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			_, _ = bw.Write([]byte("partial"))
+			return duh.NewServiceError(duh.CodeInternalError, "failed mid-stream", nil, nil)
+		})
+	}))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL, "", nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// Once bytes were written the 200 is committed; the error cannot become a Reply.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, duh.ContentOctetStream, resp.Header.Get("Content-Type"))
+	assert.Equal(t, "partial", string(body))
+	assert.NotContains(t, string(body), "failed mid-stream")
+}

--- a/bytes_writer_test.go
+++ b/bytes_writer_test.go
@@ -48,6 +48,30 @@ func TestHandleBytesStreamsBody(t *testing.T) {
 	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
 }
 
+func TestHandleBytesEmptySuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			// The handler succeeds without writing any bytes (e.g. an empty export).
+			return nil
+		})
+	}))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL, "", nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// A successful empty response still carries the standard service headers.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, body)
+	assert.Equal(t, duh.ContentOctetStream, resp.Header.Get("Content-Type"))
+	assert.Equal(t, duh.DUHVersion, resp.Header.Get(duh.HeaderDUHVersion))
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+}
+
 func TestHandleBytesHandlerOverridesHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {

--- a/reader_test.go
+++ b/reader_test.go
@@ -62,13 +62,16 @@ func TestNewReader(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, "exceeds 1.0MiB limit", err.Error())
 
+	// Drain with io.Copy to io.Discard rather than io.ReadAll. eternalReader avoids
+	// allocating the source bytes, but io.ReadAll would still accumulate every byte
+	// into a growing output slice (gigabytes) before the limit error fires.
 	r = duh.NewLimitReader(io.NopCloser(eternalReader{}), duh.Gigabyte)
-	_, err = io.ReadAll(r)
+	_, err = io.Copy(io.Discard, r)
 	require.Error(t, err)
 	assert.Equal(t, "exceeds 1.0GB limit", err.Error())
 
 	r = duh.NewLimitReader(io.NopCloser(eternalReader{}), duh.Gibibyte)
-	_, err = io.ReadAll(r)
+	_, err = io.Copy(io.Discard, r)
 	require.Error(t, err)
 	assert.Equal(t, "exceeds 1.0GiB limit", err.Error())
 }

--- a/service.go
+++ b/service.go
@@ -172,6 +172,60 @@ func WriteContent(w http.ResponseWriter, contentType string, body []byte) {
 	_, _ = w.Write(body)
 }
 
+// BytesWriter is the server-side interface for writing an unstructured
+// (octet-stream) response body, the counterpart to the client's DoBytes and the
+// unstructured analogue of StreamWriter. A handler can set response headers
+// (including overriding the default Content-Type) and write body bytes, but it
+// cannot commit the status code: HandleBytes defers WriteHeader until the first
+// Write so a handler that fails before producing any output still yields a
+// standard error Reply. Set any headers before the first Write.
+type BytesWriter interface {
+	Header() http.Header
+	io.Writer
+}
+
+// bytesWriter is the default BytesWriter. It defers the 200 status and the
+// standard service headers until the first Write, flushing each write so bytes
+// stream to the client as they are produced.
+type bytesWriter struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+	wrote   bool
+}
+
+func (b *bytesWriter) Header() http.Header {
+	return b.w.Header()
+}
+
+func (b *bytesWriter) Write(p []byte) (int, error) {
+	if !b.wrote {
+		setServiceHeaders(b.w)
+		b.w.WriteHeader(CodeOK)
+		b.wrote = true
+	}
+	n, err := b.w.Write(p)
+	if b.flusher != nil {
+		b.flusher.Flush()
+	}
+	return n, err
+}
+
+// HandleBytes writes an unstructured (octet-stream) response, the server-side
+// counterpart to the client's DoBytes and the unstructured analogue of
+// HandleStream. It seeds Content-Type: application/octet-stream (the handler MAY
+// override it via BytesWriter.Header() before the first Write), runs handler, and
+// — if the handler returns an error before any bytes were written — sends a
+// standard error Reply. Once bytes have been written the 200 response is committed
+// and the error can only abort the stream. See docs/streaming.md.
+func HandleBytes(w http.ResponseWriter, r *http.Request, handler func(*http.Request, BytesWriter) error) {
+	w.Header().Set("Content-Type", ContentOctetStream)
+	flusher, _ := w.(http.Flusher)
+	bw := &bytesWriter{w: w, flusher: flusher}
+	if err := handler(r, bw); err != nil && !bw.wrote {
+		ReplyError(w, r, err)
+	}
+}
+
 // ReplyContentError writes an error Reply for content endpoint errors.
 // It delegates to ReplyError so the Accept header is respected and the version header is set.
 // This function exists as a named entry point for content endpoint handlers, parallel to

--- a/service.go
+++ b/service.go
@@ -184,9 +184,9 @@ type BytesWriter interface {
 	io.Writer
 }
 
-// bytesWriter is the default BytesWriter. It defers the 200 status and the
-// standard service headers until the first Write, flushing each write so bytes
-// stream to the client as they are produced.
+// bytesWriter is the default BytesWriter. It defers the 200 status until the
+// first Write, flushing each write so bytes stream to the client as they are
+// produced.
 type bytesWriter struct {
 	w       http.ResponseWriter
 	flusher http.Flusher
@@ -199,7 +199,6 @@ func (b *bytesWriter) Header() http.Header {
 
 func (b *bytesWriter) Write(p []byte) (int, error) {
 	if !b.wrote {
-		setServiceHeaders(b.w)
 		b.w.WriteHeader(CodeOK)
 		b.wrote = true
 	}
@@ -219,6 +218,7 @@ func (b *bytesWriter) Write(p []byte) (int, error) {
 // and the error can only abort the stream. See docs/streaming.md.
 func HandleBytes(w http.ResponseWriter, r *http.Request, handler func(*http.Request, BytesWriter) error) {
 	w.Header().Set("Content-Type", ContentOctetStream)
+	setServiceHeaders(w)
 	flusher, _ := w.(http.Flusher)
 	bw := &bytesWriter{w: w, flusher: flusher}
 	if err := handler(r, bw); err != nil && !bw.wrote {

--- a/service.go
+++ b/service.go
@@ -235,9 +235,10 @@ func ReplyContentError(w http.ResponseWriter, r *http.Request, err error) {
 	ReplyError(w, r, err)
 }
 
-// setServiceHeaders sets the standard DUH service response headers.
-// Called by Reply and WriteContent to ensure all service responses
-// include the version header and content-type options.
+// setServiceHeaders sets the standard DUH service response headers so all
+// service responses include the version header and content-type options.
+// Called by every response writer: Reply, WriteContent, HandleBytes, and
+// HandleStream.
 func setServiceHeaders(w http.ResponseWriter) {
 	w.Header().Set(HeaderDUHVersion, DUHVersion)
 	w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/service.go
+++ b/service.go
@@ -185,8 +185,9 @@ type BytesWriter interface {
 }
 
 // bytesWriter is the default BytesWriter. It defers the 200 status until the
-// first Write, flushing each write so bytes stream to the client as they are
-// produced.
+// first Write and, when the ResponseWriter supports it, flushes each write so
+// bytes stream to the client as they are produced. Flushing is best-effort: an
+// unflushable writer still produces a correct response, just buffered.
 type bytesWriter struct {
 	w       http.ResponseWriter
 	flusher http.Flusher
@@ -203,7 +204,7 @@ func (b *bytesWriter) Write(p []byte) (int, error) {
 		b.wrote = true
 	}
 	n, err := b.w.Write(p)
-	if b.flusher != nil {
+	if err == nil && b.flusher != nil {
 		b.flusher.Flush()
 	}
 	return n, err

--- a/streaming.go
+++ b/streaming.go
@@ -124,8 +124,7 @@ func HandleStream(w http.ResponseWriter, r *http.Request, handler func(*http.Req
 	}
 
 	w.Header().Set("Content-Type", accept)
-	w.Header().Set(HeaderDUHVersion, DUHVersion)
-	w.Header().Set("X-Content-Type-Options", "nosniff")
+	setServiceHeaders(w)
 
 	sw := &streamWriter{
 		w:       stream.NewWriter(w),


### PR DESCRIPTION
### Purpose
DUH-RPC defines `application/octet-stream` as the unstructured streaming response type (raw bytes, no framing — file downloads, binary exports, raw job output). The runtime already had the *client* side (`DoBytes` → `io.ReadCloser`) and the full structured-stream lane (`DoStream`/`HandleStream`/`StreamWriter`/`StreamReader`), but no server-side primitive for writing an octet-stream response. This adds it, so `duh generate` (duh-cli ENG-96) can emit working octet-stream server handlers.

The key constraint from `docs/streaming.md`: once bytes start flowing there is no safe place to inject a Reply, so errors must be returned as a standard Reply *before any bytes are sent*. `WriteContent` can't satisfy this — it commits the 200 status immediately and takes a whole `[]byte`. `HandleBytes` defers the status/headers to the first write and tracks whether anything was written, so a handler that fails before producing output still yields a proper error Reply.

Usage (what a generated server's service implements):

```go
func (s *Service) JobsRun(ctx context.Context, req *pb.JobsRunRequest, w duh.BytesWriter) error {
    job, err := s.start(ctx, req)
    if err != nil {
        return err // before any Write -> HandleBytes sends a standard error Reply
    }
    w.Header().Set("Content-Type", "text/plain; charset=utf-8") // optional override
    w.Header().Set("X-Job-ID", job.ID)
    return job.Stream(w) // first Write commits 200 + headers; each write is flushed
}
```

This completes the symmetry across the two streaming lanes:

```
DoStream · HandleStream · StreamWriter / StreamReader   (structured)
DoBytes  · HandleBytes  · BytesWriter                   (unstructured)
```

### Implementation
- **`BytesWriter` interface** (`service.go`) — `Header() http.Header` + `io.Writer`. The service-facing type, parallel to `StreamWriter`. It can set headers and write body bytes but cannot commit the status code.
- **`HandleBytes(w, r, handler)`** (`service.go`) — the server-side counterpart to `DoBytes` and the unstructured analogue of `HandleStream`. Seeds `Content-Type: application/octet-stream` (handler may override before the first write), runs the handler, and on a pre-write error sends a standard Reply via `ReplyError`. Once bytes are written the response is committed and the error only aborts.
- **`bytesWriter`** (unexported impl) — defers `WriteHeader(200)` and the standard service headers (`X-DUH-Version`, `X-Content-Type-Options: nosniff`, via the existing `setServiceHeaders`) until the first `Write`, and best-effort flushes each write (when the `ResponseWriter` is an `http.Flusher`) so bytes stream as produced.
- **`bytes_writer_test.go`** — httptest coverage: happy-path streaming + standard headers, handler header override, error-before-first-byte → standard Reply, and error-after-first-byte → committed stream (no Reply injected).