### PR TITLE
content: HandleBytes pre-body errors negotiate by Accept only (ENG-138)

### DIFF
--- a/bytes_writer_test.go
+++ b/bytes_writer_test.go
@@ -21,8 +21,11 @@ import (
 	"testing"
 
 	"github.com/duh-rpc/duh.go/v2"
+	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	protojson "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestHandleBytesStreamsBody(t *testing.T) {
@@ -117,6 +120,147 @@ func TestHandleBytesErrorBeforeFirstByte(t *testing.T) {
 	assert.Equal(t, duh.DUHVersion, resp.Header.Get(duh.HeaderDUHVersion))
 	assert.NotEqual(t, duh.ContentOctetStream, resp.Header.Get("Content-Type"))
 	assert.Contains(t, string(body), "bad input")
+}
+
+// A content endpoint's pre-body error must fall back to a JSON Reply when the
+// client's Accept is the endpoint's own (non-Reply-capable) success media type,
+// rather than masking the real status with a 455.
+func TestHandleBytesPreBodyErrorFallsBackToJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			return duh.NewServiceError(duh.CodeNotFound, "path not found", nil, nil)
+		})
+	}))
+	defer server.Close()
+
+	for _, test := range []struct {
+		name   string
+		accept string
+	}{
+		{name: "octet-stream", accept: duh.ContentOctetStream},
+		{name: "text/html", accept: "text/html"},
+		{name: "text/html with charset", accept: "text/html; charset=utf-8"},
+		{name: "image/png", accept: "image/png"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, server.URL, nil)
+			require.NoError(t, err)
+			req.Header.Set("Accept", test.accept)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			// The real 404 survives — no 455 masking it.
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+			assert.Equal(t, duh.ContentTypeJSON, resp.Header.Get("Content-Type"))
+			assert.Equal(t, duh.DUHVersion, resp.Header.Get(duh.HeaderDUHVersion))
+
+			var reply v1.Reply
+			require.NoError(t, protojson.Unmarshal(body, &reply))
+			assert.Equal(t, "404", reply.GetCode())
+			assert.Equal(t, "path not found", reply.GetMessage())
+		})
+	}
+}
+
+// A protobuf client of a content endpoint (request Content-Type: application/protobuf)
+// gets a protobuf-encoded error Reply, not a force-JSON one.
+func TestHandleBytesPreBodyErrorPrefersProtobuf(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			return duh.NewServiceError(duh.CodeUnauthorized, "not allowed", nil, nil)
+		})
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", duh.ContentTypeProtoBuf)
+	req.Header.Set("Accept", duh.ContentOctetStream)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, duh.ContentTypeProtoBuf, resp.Header.Get("Content-Type"))
+
+	var reply v1.Reply
+	require.NoError(t, proto.Unmarshal(body, &reply))
+	assert.Equal(t, "401", reply.GetCode())
+	assert.Equal(t, "not allowed", reply.GetMessage())
+}
+
+// A Reply-capable Accept passes through unchanged: an explicit JSON Accept still
+// negotiates to JSON even when the request Content-Type is protobuf.
+func TestHandleBytesPreBodyErrorRespectsReplyCapableAccept(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			return duh.NewServiceError(duh.CodeBadRequest, "bad input", nil, nil)
+		})
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", duh.ContentTypeProtoBuf)
+	req.Header.Set("Accept", duh.ContentTypeJSON)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, duh.ContentTypeJSON, resp.Header.Get("Content-Type"))
+
+	var reply v1.Reply
+	require.NoError(t, protojson.Unmarshal(body, &reply))
+	assert.Equal(t, "400", reply.GetCode())
+}
+
+// A service may override ReplyContentError to produce a custom, non-JSON error
+// representation (e.g. an HTML error page) without patching the framework.
+func TestHandleBytesReplyContentErrorOverridable(t *testing.T) {
+	original := duh.ReplyContentError
+	defer func() { duh.ReplyContentError = original }()
+
+	duh.ReplyContentError = func(w http.ResponseWriter, r *http.Request, err error) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("<html><body>not found</body></html>"))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			return duh.NewServiceError(duh.CodeNotFound, "path not found", nil, nil)
+		})
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", duh.ContentOctetStream)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+	assert.Contains(t, string(body), "not found")
 }
 
 func TestHandleBytesErrorAfterFirstByteIsCommitted(t *testing.T) {

--- a/bytes_writer_test.go
+++ b/bytes_writer_test.go
@@ -24,7 +24,7 @@ import (
 	v1 "github.com/duh-rpc/duh.go/v2/proto/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	protojson "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -226,6 +226,34 @@ func TestHandleBytesPreBodyErrorRespectsReplyCapableAccept(t *testing.T) {
 	var reply v1.Reply
 	require.NoError(t, protojson.Unmarshal(body, &reply))
 	assert.Equal(t, "400", reply.GetCode())
+}
+
+// Negotiating the error encoding must not mutate the caller's request: middleware
+// that reads r.Header after HandleBytes returns must still see the client's Accept.
+func TestHandleBytesPreBodyErrorDoesNotMutateRequest(t *testing.T) {
+	observed := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			return duh.NewServiceError(duh.CodeNotFound, "path not found", nil, nil)
+		})
+		// Outer middleware observes the request after the content handler returns.
+		observed <- r.Header.Get("Accept")
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "image/png")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The error still negotiated to a JSON Reply...
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, duh.ContentTypeJSON, resp.Header.Get("Content-Type"))
+	// ...but the client's original Accept survives on the request.
+	assert.Equal(t, "image/png", <-observed)
 }
 
 // A service may override ReplyContentError to produce a custom, non-JSON error

--- a/bytes_writer_test.go
+++ b/bytes_writer_test.go
@@ -167,9 +167,9 @@ func TestHandleBytesPreBodyErrorFallsBackToJSON(t *testing.T) {
 	}
 }
 
-// A protobuf client of a content endpoint (request Content-Type: application/protobuf)
-// gets a protobuf-encoded error Reply, not a force-JSON one.
-func TestHandleBytesPreBodyErrorPrefersProtobuf(t *testing.T) {
+// A client that explicitly sets Accept: application/protobuf gets a protobuf-encoded
+// error Reply, regardless of the request Content-Type.
+func TestHandleBytesPreBodyErrorExplicitProtobufAccept(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
 			return duh.NewServiceError(duh.CodeUnauthorized, "not allowed", nil, nil)
@@ -179,8 +179,8 @@ func TestHandleBytesPreBodyErrorPrefersProtobuf(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodPost, server.URL, nil)
 	require.NoError(t, err)
-	req.Header.Set("Content-Type", duh.ContentTypeProtoBuf)
-	req.Header.Set("Accept", duh.ContentOctetStream)
+	req.Header.Set("Content-Type", duh.ContentOctetStream)
+	req.Header.Set("Accept", duh.ContentTypeProtoBuf)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -196,6 +196,49 @@ func TestHandleBytesPreBodyErrorPrefersProtobuf(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(body, &reply))
 	assert.Equal(t, "401", reply.GetCode())
 	assert.Equal(t, "not allowed", reply.GetMessage())
+}
+
+// The request Content-Type MUST NOT influence error encoding. A protobuf Content-Type
+// with a non-Reply-capable (or empty) Accept still yields a JSON error Reply.
+func TestHandleBytesPreBodyErrorContentTypeIgnored(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			return duh.NewServiceError(duh.CodeUnauthorized, "not allowed", nil, nil)
+		})
+	}))
+	defer server.Close()
+
+	for _, test := range []struct {
+		name   string
+		accept string
+	}{
+		{name: "octet-stream accept", accept: duh.ContentOctetStream},
+		{name: "empty accept", accept: ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, server.URL, nil)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", duh.ContentTypeProtoBuf)
+			if test.accept != "" {
+				req.Header.Set("Accept", test.accept)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+			assert.Equal(t, duh.ContentTypeJSON, resp.Header.Get("Content-Type"))
+
+			var reply v1.Reply
+			require.NoError(t, protojson.Unmarshal(body, &reply))
+			assert.Equal(t, "401", reply.GetCode())
+			assert.Equal(t, "not allowed", reply.GetMessage())
+		})
+	}
 }
 
 // A Reply-capable Accept passes through unchanged: an explicit JSON Accept still
@@ -256,21 +299,19 @@ func TestHandleBytesPreBodyErrorDoesNotMutateRequest(t *testing.T) {
 	assert.Equal(t, "image/png", <-observed)
 }
 
-// A service may override ReplyContentError to produce a custom, non-JSON error
-// representation (e.g. an HTML error page) without patching the framework.
-func TestHandleBytesReplyContentErrorOverridable(t *testing.T) {
-	original := duh.ReplyContentError
-	defer func() { duh.ReplyContentError = original }()
-
-	duh.ReplyContentError = func(w http.ResponseWriter, r *http.Request, err error) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte("<html><body>not found</body></html>"))
-	}
-
+// A HandleBytes handler that wants a non-standard error representation (e.g. an HTML
+// error page) writes its own response to the ResponseWriter it holds in closure scope
+// and returns nil; HandleBytes must not overwrite it with a standard Reply.
+func TestHandleBytesHandlerRendersOwnError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
-			return duh.NewServiceError(duh.CodeNotFound, "path not found", nil, nil)
+			// Render a custom error straight to w so the handler owns the status, then
+			// return nil so HandleBytes leaves the response untouched. Writing through bw
+			// would commit 200; the raw ResponseWriter lets the handler set 404.
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("<html><body>not found</body></html>"))
+			return nil
 		})
 	}))
 	defer server.Close()
@@ -288,6 +329,7 @@ func TestHandleBytesReplyContentErrorOverridable(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+	assert.Equal(t, duh.DUHVersion, resp.Header.Get(duh.HeaderDUHVersion))
 	assert.Contains(t, string(body), "not found")
 }
 

--- a/docs/features/ENG-138-content-endpoint-errors/handlebytes-errors-explainer.html
+++ b/docs/features/ENG-138-content-endpoint-errors/handlebytes-errors-explainer.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>HandleBytes pre-body errors — Guide</title>
+<style>
+  /* ── Design tokens — canonical source: docs/design.md ───────────────── */
+  :root {
+    --bg: #0d1117;          /* page canvas              (colors.background)    */
+    --panel: #161b22;       /* cards, callouts          (colors.surface)       */
+    --panel-2: #1c2230;     /* raised: table headers    (colors.surfaceRaised) */
+    --border: #30363d;      /* hairline borders         (colors.border)        */
+    --text: #e6edf3;        /* body text                (colors.onBackground)  */
+    --muted: #9da7b3;       /* supporting text          (colors.onBackgroundMuted) */
+    --accent: #58a6ff;      /* links, emphasis (blue)   (colors.primary)       */
+    --accent-2: #7ee787;    /* headings, CLI (green)    (colors.secondary)     */
+    --warn: #f0883e;        /* caution                  (colors.warning)       */
+    --danger: #ff7b72;      /* danger                   (colors.error)         */
+    --code-bg: #0b0f14;     /* code surface             (colors.codeSurface)   */
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.65;
+  }
+  /* Single centred reading column — NO sidebar. */
+  .layout { max-width: 880px; margin: 0 auto; }
+  main { padding: 3rem 2rem 6rem; }
+  h1 { font-size: 2.1rem; line-height: 1.2; margin: 0 0 .4rem; }
+  h2 { font-size: 1.5rem; margin: 3rem 0 1rem; padding-bottom: .4rem; border-bottom: 1px solid var(--border); }
+  h3 { font-size: 1.18rem; margin: 2rem 0 .6rem; color: var(--accent-2); }
+  h4 { font-size: 1rem; margin: 1.4rem 0 .4rem; color: var(--text); }
+  p, li { color: var(--text); }
+  a { color: var(--accent); }
+  code {
+    font-family: var(--mono); font-size: .86em;
+    background: var(--code-bg); border: 1px solid var(--border);
+    border-radius: 5px; padding: .1em .4em;
+  }
+  pre {
+    background: var(--code-bg); border: 1px solid var(--border);
+    border-radius: 8px; padding: 1rem 1.1rem; overflow-x: auto;
+    font-size: .85rem; line-height: 1.55;
+  }
+  pre code { background: none; border: none; padding: 0; font-size: inherit; }
+  .lead {
+    font-size: 1.15rem; color: var(--muted);
+    border-left: 3px solid var(--accent); padding-left: 1rem; margin: 1.5rem 0 2rem;
+  }
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: .9rem; }
+  th, td { text-align: left; padding: .55rem .7rem; border: 1px solid var(--border); vertical-align: top; }
+  th { background: var(--panel-2); color: var(--text); font-weight: 600; }
+  tr:nth-child(even) td { background: rgba(255,255,255,.015); }
+  /* Callouts — tip / warn / danger encode intent via left border + eyebrow colour */
+  .callout { border-radius: 8px; padding: .9rem 1.1rem; margin: 1.2rem 0; border: 1px solid var(--border); background: var(--panel); }
+  .callout.tip    { border-left: 4px solid var(--accent-2); }
+  .callout.warn   { border-left: 4px solid var(--warn); }
+  .callout.danger { border-left: 4px solid var(--danger); }
+  .callout .label { font-weight: 700; font-size: .72rem; letter-spacing: .1em; text-transform: uppercase; display: block; margin-bottom: .3rem; }
+  .callout.tip .label    { color: var(--accent-2); }
+  .callout.warn .label   { color: var(--warn); }
+  .callout.danger .label { color: var(--danger); }
+  /* Pills / tags */
+  .pill { display: inline-block; font-size: .68rem; letter-spacing: .06em; text-transform: uppercase; font-weight: 700; padding: .12rem .55rem; border-radius: 999px; border: 1px solid var(--border); color: var(--muted); vertical-align: middle; }
+  /* Tinted pill variants — duplicate this pattern with your own accent + 55/12 alpha suffixes */
+  .pill.a { color: var(--accent);   border-color: #58a6ff55; background:#58a6ff12; }
+  .pill.b { color: var(--accent-2); border-color: #7ee78755; background:#7ee78712; }
+  .pill.c { color: #b48ead;         border-color: #b48ead55; background:#b48ead12; }
+  /* Numbered layer/step diagram */
+  .layers { margin: 1.5rem 0; }
+  .layer { display: flex; align-items: stretch; border: 1px solid var(--border); border-radius: 8px; margin-bottom: .6rem; overflow: hidden; background: var(--panel); }
+  .layer .num { flex: 0 0 56px; display: flex; align-items: center; justify-content: center; font-size: 1.4rem; font-weight: 700; background: var(--panel-2); color: var(--accent); }
+  .layer .body { padding: .7rem 1rem; flex: 1; }
+  .layer .body .t { font-weight: 600; }
+  .layer .body .d { color: var(--muted); font-size: .9rem; }
+  .layer .owner { flex: 0 0 130px; display:flex; align-items:center; justify-content:center; font-size: .72rem; text-align:center; border-left: 1px solid var(--border); }
+  /* Card grid */
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  .card { border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.1rem; background: var(--panel); }
+  .card h4 { margin-top: 0; }
+  .muted { color: var(--muted); }
+  .cmd { color: var(--accent-2); }   /* CLI/command text inside <pre> */
+  hr { border: none; border-top: 1px solid var(--border); margin: 2.5rem 0; }
+  footer { color: var(--muted); font-size: .85rem; margin-top: 4rem; border-top: 1px solid var(--border); padding-top: 1.2rem; }
+  @media (max-width: 900px) {
+    main { padding: 2rem 1.2rem 4rem; }
+    .grid2 { grid-template-columns: 1fr; }
+  }
+  /* ── Explainer diagrams ─────────────────────────────────────────────── */
+  /* Flow: boxes joined by arrows. Add .vert for top-to-bottom. */
+  .flow { display: flex; align-items: stretch; gap: 0; flex-wrap: wrap; margin: 1.5rem 0; }
+  .flow.vert { flex-direction: column; align-items: flex-start; }
+  .flow .node {
+    border: 1px solid var(--border); border-radius: 8px; background: var(--panel);
+    padding: .7rem 1rem; min-width: 120px; text-align: center;
+  }
+  .flow .node .t { font-weight: 600; font-size: .95rem; }
+  .flow .node .d { color: var(--muted); font-size: .82rem; }
+  .flow .node.surface { border-color: #58a6ff55; background: #58a6ff12; }  /* caller-facing */
+  .flow .node.inside  { border-color: var(--border); background: var(--panel-2); }  /* internal */
+  .flow .arrow { display: flex; align-items: center; justify-content: center; padding: 0 .7rem; color: var(--accent); font-size: 1.3rem; }
+  .flow.vert .arrow { padding: .35rem 0 .35rem 2.2rem; }
+  .flow .arrow .lbl { color: var(--muted); font-size: .72rem; margin-left: .35rem; }
+
+  /* Boundary: the surface (highlighted) wrapping the internals (dimmed). */
+  .boundary { border: 1px solid #58a6ff55; border-radius: 10px; background: #58a6ff0a; padding: 1rem; margin: 1.5rem 0; }
+  .boundary > .cap { font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: .6rem; }
+  .boundary .inner { border: 1px dashed var(--border); border-radius: 8px; background: var(--panel); padding: .9rem; }
+  .boundary .inner > .cap { font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; color: var(--muted); font-weight: 700; margin-bottom: .5rem; }
+
+  /* SVG diagram wrapper (state machines, sequences) */
+  .diagram { width: 100%; margin: 1.5rem 0; }
+  .diagram text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: var(--text); }
+  .diagram .node-box { fill: var(--panel); stroke: var(--border); }
+  .diagram .node-box.surface { fill: #58a6ff12; stroke: #58a6ff88; }
+  .diagram .edge { stroke: var(--accent); stroke-width: 1.5; fill: none; }
+  .diagram .edge-lbl { fill: var(--muted); font-size: 12px; }
+  .diagram .muted { fill: var(--muted); }
+</style>
+</head>
+<body>
+<div class="layout">
+<main>
+
+<h1>Errors from a <code>HandleBytes</code> content endpoint</h1>
+<p class="lead">
+  You serve raw content — a file, an image, an HTML page — through
+  <code>HandleBytes</code>. When your handler fails <em>before</em> it writes the first byte,
+  the client now gets your real HTTP status and a decodable error body. No more
+  <code>455</code> swallowing your <code>404</code>.
+</p>
+
+<p>
+  This is a behavior change for anyone writing content endpoints with
+  <code>duh.HandleBytes</code>. Nothing in your handler signature changes — you write the
+  same three-argument handler you always did. What changed is what the client receives when
+  that handler returns an error early. This guide is written for you, the handler author:
+  what you send, what your client gets back, and one new trick for custom error pages.
+</p>
+
+<!-- ============================================================= -->
+<h2 id="boundary">What you hand in, what the client gets back</h2>
+
+<div class="boundary">
+  <div class="cap">Your side — the handler you write</div>
+  <p class="muted">
+    Return <code>nil</code> and the bytes you wrote become a <code>200</code>.
+    Return an <code>error</code> before writing anything, and DUH turns it into a
+    standard <code>Reply</code> for the client.
+  </p>
+  <div class="inner">
+    <div class="cap">DUH's job (you don't call this)</div>
+    <p class="muted">
+      Pick an encoding the client's DUH client can actually decode, write the status
+      and the <code>Reply</code> body, set the service headers. This is the part that
+      changed.
+    </p>
+  </div>
+</div>
+
+<p>
+  A content endpoint's success responses use the content's own media type —
+  <code>application/octet-stream</code>, <code>image/png</code>, <code>text/html</code>.
+  That is what the client puts in its <code>Accept</code> header. But none of those media
+  types can carry a structured error <code>Reply</code>. So when your handler errors before
+  producing content, DUH has to answer in something the client can decode instead.
+</p>
+
+<div class="flow">
+  <div class="node surface"><div class="t">your handler</div><div class="d">return err</div></div>
+  <div class="arrow">→<span class="lbl">before 1st byte</span></div>
+  <div class="node inside"><div class="t">HandleBytes</div><div class="d">ReplyContentError</div></div>
+  <div class="arrow">→<span class="lbl">JSON by default</span></div>
+  <div class="node surface"><div class="t">client</div><div class="d">decodes v1.Reply</div></div>
+</div>
+
+<!-- ============================================================= -->
+<h2 id="change">The change, in one before/after</h2>
+
+<p>
+  Say your handler serves images and the client requested
+  <code>Accept: image/png</code>. Your handler can't find the record, so it returns a
+  <code>404</code>.
+</p>
+
+<div class="grid2">
+  <div class="card"><h4>Before — the bug</h4>
+    <pre><code><span class="muted">// client: Accept: image/png</span>
+<span class="muted">// handler: return 404</span>
+
+HTTP/1.1 <span class="cmd">455</span> ...
+<span class="muted"># "image/png is not supported,</span>
+<span class="muted">#  only [json, protobuf]"</span>
+<span class="muted"># your 404 is gone.</span></code></pre></div>
+  <div class="card"><h4>After — the fix</h4>
+    <pre><code><span class="muted">// client: Accept: image/png</span>
+<span class="muted">// handler: return 404</span>
+
+HTTP/1.1 <span class="cmd">404</span> Not Found
+Content-Type: application/json
+
+{"code":"404","message":"..."}
+<span class="muted"># real status + decodable body.</span></code></pre></div>
+</div>
+
+<p>
+  Before, DUH tried to encode the error in the client's <code>Accept</code> media type,
+  failed (you can't put a <code>Reply</code> in a PNG), and returned <code>455 Unsupported
+  Media Type</code> — masking the <code>404</code> you actually returned. Now the pre-body
+  error falls back to JSON, which every DUH client links and can always decode. Your status
+  survives.
+</p>
+
+<div class="callout tip"><span class="label">Why JSON works everywhere</span>
+  The DUH client decodes an error by the <em>response's</em> <code>Content-Type</code>, and
+  it always links the JSON codec. So a JSON error body is universally decodable regardless of
+  what the client asked for. That is why JSON is the fallback.
+</div>
+
+<!-- ============================================================= -->
+<h2 id="rules">The rules you can rely on</h2>
+
+<p>Given a pre-body error (your handler returns non-nil before the first <code>Write</code>):</p>
+
+<table>
+  <thead><tr><th>Client sends</th><th>Client gets the error as</th></tr></thead>
+  <tbody>
+    <tr><td><code>Accept: application/octet-stream</code> / <code>image/png</code> / <code>text/html</code> / empty</td><td><span class="pill b">JSON</span> — the universal fallback</td></tr>
+    <tr><td><code>Accept: application/json</code></td><td><span class="pill b">JSON</span></td></tr>
+    <tr><td><code>Accept: application/protobuf</code></td><td><span class="pill a">Protobuf</span> — explicit opt-in</td></tr>
+    <tr><td>any <code>Content-Type</code> on the request</td><td><span class="muted">ignored — does not affect error encoding</span></td></tr>
+  </tbody>
+</table>
+
+<p>Two rules are worth committing to memory:</p>
+
+<h3>1. Protobuf only when the client explicitly asks for it</h3>
+<p>
+  The error is JSON unless the client sets <code>Accept: application/protobuf</code>. That's
+  the only way to get a protobuf error <code>Reply</code>.
+</p>
+
+<h3>2. The request <code>Content-Type</code> never decides the error encoding</h3>
+<p>
+  <code>Content-Type</code> describes the body the client <em>sent</em> you (e.g. the blob
+  it's uploading). <code>Accept</code> describes the response it wants. Only <code>Accept</code>
+  is consulted. If you relied on "I uploaded protobuf, so I'll get a protobuf error" — that
+  never was a sound assumption, and it's now explicitly gone.
+</p>
+
+<div class="callout warn"><span class="label">If you tracked the original ticket</span>
+  The first acceptance criterion — "request <code>Content-Type: protobuf</code> → protobuf
+  error" — was itself the bug. Error encoding is negotiated by <code>Accept</code> only.
+  <code>455</code> is now reserved for a <em>structured</em> endpoint receiving a success
+  <code>Accept</code> it genuinely cannot satisfy — never for a content-endpoint error.
+</div>
+
+<!-- ============================================================= -->
+<h2 id="custom">New: render your own error page</h2>
+
+<p>
+  Sometimes you don't want a JSON <code>Reply</code> at all — you want an HTML error page, or
+  a redirect, or some bespoke body. You can, because <code>HandleBytes</code> defers the
+  status line until your first write. The move: <strong>write your own response, then return
+  <code>nil</code></strong>. Returning <code>nil</code> tells <code>HandleBytes</code> you've
+  already answered, so it won't also send a <code>Reply</code>.
+</p>
+
+<pre><code>func(w http.ResponseWriter, r *http.Request) {
+    duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+        rec, err := store.Find(r.Context(), id)
+        if err != nil {
+            <span class="muted">// Render your own error straight to w and claim the status.</span>
+            w.Header().Set("Content-Type", "text/html; charset=utf-8")
+            w.WriteHeader(http.StatusNotFound)
+            _, _ = w.Write([]byte("&lt;html&gt;&lt;body&gt;not found&lt;/body&gt;&lt;/html&gt;"))
+            <span class="cmd">return nil</span>   <span class="muted">// nil == "I answered; don't send a Reply"</span>
+        }
+        _, err = bw.Write(rec.Bytes)
+        return err
+    })
+}</code></pre>
+
+<div class="callout danger"><span class="label">One response only</span>
+  Write your own response <em>or</em> return an error — never both. If you write a full
+  response and <em>also</em> return a non-nil error, two responses get written. The contract:
+  return <code>nil</code> when you've handled it yourself; return a non-nil error only to get
+  the standard <code>Reply</code>.
+</div>
+
+<div class="callout warn"><span class="label">Custom status needs the raw writer</span>
+  To set a status other than <code>200</code>, write to the <code>http.ResponseWriter</code>
+  (<code>w</code>) you already hold in the closure, as above. Writing through
+  <code>bw</code> (the <code>BytesWriter</code>) commits <code>200</code> on the first write —
+  that's the success path, not the error path.
+</div>
+
+<!-- ============================================================= -->
+<h2 id="whyremoved">Why there's no override hook anymore</h2>
+
+<p>
+  A previous iteration exposed a package-level <code>ReplyContentError</code> variable you
+  could reassign to customize error rendering globally. That's gone, replaced by the
+  return-<code>nil</code> pattern above. Two reasons, both about your safety:
+</p>
+
+<div class="grid2">
+  <div class="card"><h4>It was a data race</h4><p class="muted">
+    A mutable package <code>var</code> reassigned at startup and read on every request is a
+    race the detector flags. A plain function has no such hazard.
+  </p></div>
+  <div class="card"><h4>It leaked globally</h4><p class="muted">
+    Reassigning it changed error rendering for <em>every</em> content endpoint in the
+    process. Per-endpoint customization now lives in the one handler that wants it — where it
+    belongs.
+  </p></div>
+</div>
+
+<p>
+  <code>duh.ReplyContentError</code> still exists as a regular exported function you can call,
+  but it is no longer a variable and cannot be reassigned. If you need custom error output,
+  render it in your handler and return <code>nil</code>.
+</p>
+
+<!-- ============================================================= -->
+<h2 id="checklist">What to check in your handlers</h2>
+
+<div class="layers">
+  <div class="layer">
+    <div class="num">1</div>
+    <div class="body"><div class="t">Nothing to change for the common case</div><div class="d">Return an error before writing → the client now gets your real status as JSON. This is strictly better; no code change needed.</div></div>
+    <div class="owner"><span class="pill b">automatic</span></div>
+  </div>
+  <div class="layer">
+    <div class="num">2</div>
+    <div class="body"><div class="t">Stop relying on request Content-Type for error format</div><div class="d">If any client assumed an upload's Content-Type would shape the error, switch it to send Accept: application/protobuf instead.</div></div>
+    <div class="owner"><span class="pill a">action</span></div>
+  </div>
+  <div class="layer">
+    <div class="num">3</div>
+    <div class="body"><div class="t">Replace any ReplyContentError reassignment</div><div class="d">If you set duh.ReplyContentError = ..., move that logic into the handler: write your response, return nil.</div></div>
+    <div class="owner"><span class="pill a">action</span></div>
+  </div>
+</div>
+
+<footer>
+  Generated from the ENG-138 change on branch
+  <code>thrawn01/eng-138-duhgo-content-endpoint-handlebytes-pre-body-errors-must-fall</code>
+  (<code>service.go</code>, <code>bytes_writer_test.go</code>, <code>docs/spec.md</code>).
+  Styling per the html-explainer template.
+</footer>
+
+</main>
+</div>
+</body>
+</html>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -93,6 +93,8 @@ Accept header 'application/bson' is invalid format or unrecognized content type,
 
 > Server MUST ALWAYS support JSON, if no other content type can be negotiated, then the server will always respond with JSON.
 
+> The `455` above is reserved for a structured-endpoint **success** the client genuinely cannot accept. It MUST NOT be used for a content-endpoint error. A content endpoint's success `Accept` (e.g. `application/octet-stream`, `image/png`, `text/html`) cannot carry a structured Reply, so a **pre-body error** — one raised before any content bytes are written — is a standard Reply encoded by the JSON fallback rule: it defaults to `application/json` and MAY be `application/protobuf` only when the client explicitly sets `Accept: application/protobuf`. The request `Content-Type` MUST NOT influence error encoding — `Content-Type` describes the sent body, while `Accept` describes the desired response representation. See [Content Endpoints](#content-endpoints).
+
 The reason we simplify Content-Type handling here is so servers with high performance requirements or tight resource constraints can support the DUH-RPC spec without needing to support every edge case RFC for HTTP.
 
 ## Replies

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 Derrick J Wippler
+
+Licensed under the MIT License, you may obtain a copy of the License at
+
+https://opensource.org/license/mit/ or in the root of this code repo
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duh_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/duh-rpc/duh.go/v2"
+)
+
+// A HandleBytes handler may render its own error response instead of the standard
+// JSON/protobuf Reply — an HTML error page, say. Write the response directly to the
+// http.ResponseWriter held in closure scope, then return nil so HandleBytes does not
+// also send a Reply. Return a non-nil error only to get the standard Reply — never
+// both, or two responses are written.
+//
+// Writing through the BytesWriter commits a 200 on the first write, so to set a
+// different status (404 here) write to the raw ResponseWriter.
+func ExampleHandleBytes_renderOwnError() {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
+			// The requested record was not found; answer with a custom HTML page.
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("<html><body>not found</body></html>"))
+			return nil // nil == "I answered; don't send a Reply"
+		})
+	}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	fmt.Println(resp.StatusCode)
+	fmt.Println(resp.Header.Get("Content-Type"))
+	fmt.Println(string(body))
+	// Output:
+	// 404
+	// text/html; charset=utf-8
+	// <html><body>not found</body></html>
+}

--- a/service.go
+++ b/service.go
@@ -227,30 +227,36 @@ func HandleBytes(w http.ResponseWriter, r *http.Request, handler func(*http.Requ
 	}
 }
 
-// ReplyContentError writes a pre-body error Reply for a content endpoint (see HandleBytes).
-// A content endpoint's success Accept — application/octet-stream, text/html, image/png, … —
-// is not a Reply-capable media type, but the spec requires the error to still be a decodable
-// Reply (docs/spec.md §Content Negotiation, docs/streaming.md §Unstructured Streams). So when
-// Accept is not json/protobuf, it is rewritten to a Reply-capable encoding — protobuf when the
-// client sent a protobuf request Content-Type, otherwise JSON — rather than letting Reply 455
-// on the success Accept and mask the real error. A Reply-capable Accept passes through unchanged
-// and negotiates normally.
-//
-// ReplyContentError is a var so a service with a legitimate custom error representation (e.g. an
-// HTML error page on a browser-facing content endpoint) can override it without patching the
-// framework.
-var ReplyContentError = func(w http.ResponseWriter, r *http.Request, err error) {
-	switch normalizeMediaType(r.Header.Get("Accept")) {
+// replyCapable reports whether a media type can carry a standard Reply — the set
+// Reply negotiates. Content endpoints use it to know when a success Accept
+// (octet-stream, text/html, image/*, …) must fall back to a Reply-capable encoding.
+func replyCapable(mimeType string) bool {
+	switch mimeType {
 	case "", "*/*", "application/*", ContentTypeJSON, ContentTypeProtoBuf:
-		// Already Reply-capable; let Reply negotiate it as-is.
+		return true
 	default:
-		if normalizeMediaType(r.Header.Get("Content-Type")) == ContentTypeProtoBuf {
-			r.Header.Set("Accept", ContentTypeProtoBuf)
-		} else {
-			r.Header.Set("Accept", ContentTypeJSON)
-		}
+		return false
 	}
-	ReplyError(w, r, err)
+}
+
+// ReplyContentError writes a content endpoint's pre-body error as a Reply. A content
+// endpoint's success Accept is not Reply-capable, so it is negotiated to a Reply-capable
+// encoding here rather than letting Reply 455 on it and mask the real error (spec
+// §Content Negotiation). It is a var so a service can substitute a custom error format.
+var ReplyContentError = func(w http.ResponseWriter, r *http.Request, err error) {
+	if replyCapable(normalizeMediaType(r.Header.Get("Accept"))) {
+		ReplyError(w, r, err)
+		return
+	}
+	// Prefer protobuf for a protobuf client, else the universal JSON fallback. Clone so
+	// the negotiation override is not visible to callers/middleware that still hold r.
+	accept := ContentTypeJSON
+	if normalizeMediaType(r.Header.Get("Content-Type")) == ContentTypeProtoBuf {
+		accept = ContentTypeProtoBuf
+	}
+	clone := r.Clone(r.Context())
+	clone.Header.Set("Accept", accept)
+	ReplyError(w, clone, err)
 }
 
 // setServiceHeaders sets the standard DUH service response headers so all

--- a/service.go
+++ b/service.go
@@ -223,15 +223,33 @@ func HandleBytes(w http.ResponseWriter, r *http.Request, handler func(*http.Requ
 	flusher, _ := w.(http.Flusher)
 	bw := &bytesWriter{w: w, flusher: flusher}
 	if err := handler(r, bw); err != nil && !bw.wrote {
-		ReplyError(w, r, err)
+		ReplyContentError(w, r, err)
 	}
 }
 
-// ReplyContentError writes an error Reply for content endpoint errors.
-// It delegates to ReplyError so the Accept header is respected and the version header is set.
-// This function exists as a named entry point for content endpoint handlers, parallel to
-// ReplyError for structured handlers, allowing future content-specific behavior.
-func ReplyContentError(w http.ResponseWriter, r *http.Request, err error) {
+// ReplyContentError writes a pre-body error Reply for a content endpoint (see HandleBytes).
+// A content endpoint's success Accept — application/octet-stream, text/html, image/png, … —
+// is not a Reply-capable media type, but the spec requires the error to still be a decodable
+// Reply (docs/spec.md §Content Negotiation, docs/streaming.md §Unstructured Streams). So when
+// Accept is not json/protobuf, it is rewritten to a Reply-capable encoding — protobuf when the
+// client sent a protobuf request Content-Type, otherwise JSON — rather than letting Reply 455
+// on the success Accept and mask the real error. A Reply-capable Accept passes through unchanged
+// and negotiates normally.
+//
+// ReplyContentError is a var so a service with a legitimate custom error representation (e.g. an
+// HTML error page on a browser-facing content endpoint) can override it without patching the
+// framework.
+var ReplyContentError = func(w http.ResponseWriter, r *http.Request, err error) {
+	switch normalizeMediaType(r.Header.Get("Accept")) {
+	case "", "*/*", "application/*", ContentTypeJSON, ContentTypeProtoBuf:
+		// Already Reply-capable; let Reply negotiate it as-is.
+	default:
+		if normalizeMediaType(r.Header.Get("Content-Type")) == ContentTypeProtoBuf {
+			r.Header.Set("Accept", ContentTypeProtoBuf)
+		} else {
+			r.Header.Set("Accept", ContentTypeJSON)
+		}
+	}
 	ReplyError(w, r, err)
 }
 

--- a/service.go
+++ b/service.go
@@ -217,6 +217,10 @@ func (b *bytesWriter) Write(p []byte) (int, error) {
 // — if the handler returns an error before any bytes were written — sends a
 // standard error Reply. Once bytes have been written the 200 response is committed
 // and the error can only abort the stream. See docs/streaming.md.
+//
+// If the handler renders its own response before the first Write, it must return nil;
+// return a non-nil error only to get the standard Reply — never both, or two responses
+// are written.
 func HandleBytes(w http.ResponseWriter, r *http.Request, handler func(*http.Request, BytesWriter) error) {
 	w.Header().Set("Content-Type", ContentOctetStream)
 	setServiceHeaders(w)
@@ -239,23 +243,23 @@ func replyCapable(mimeType string) bool {
 	}
 }
 
-// ReplyContentError writes a content endpoint's pre-body error as a Reply. A content
-// endpoint's success Accept is not Reply-capable, so it is negotiated to a Reply-capable
-// encoding here rather than letting Reply 455 on it and mask the real error (spec
-// §Content Negotiation). It is a var so a service can substitute a custom error format.
-var ReplyContentError = func(w http.ResponseWriter, r *http.Request, err error) {
+// ReplyContentError writes a content endpoint's pre-body error as a standard Reply.
+// The success Accept (octet-stream, image/*, …) can't carry a structured Reply, so the
+// error defaults to JSON — the spec's universal fallback; a client gets protobuf only by
+// negotiating it explicitly via Accept: application/protobuf. Request Content-Type never
+// influences error encoding (it describes the sent body, not the desired response).
+//
+// To emit a non-standard error (e.g. an HTML page), a HandleBytes handler writes its own
+// response to the ResponseWriter and returns nil instead of returning the error — see HandleBytes.
+func ReplyContentError(w http.ResponseWriter, r *http.Request, err error) {
 	if replyCapable(normalizeMediaType(r.Header.Get("Accept"))) {
-		ReplyError(w, r, err)
+		ReplyError(w, r, err) // explicit json/protobuf Accept negotiates normally
 		return
 	}
-	// Prefer protobuf for a protobuf client, else the universal JSON fallback. Clone so
-	// the negotiation override is not visible to callers/middleware that still hold r.
-	accept := ContentTypeJSON
-	if normalizeMediaType(r.Header.Get("Content-Type")) == ContentTypeProtoBuf {
-		accept = ContentTypeProtoBuf
-	}
+	// Opaque success Accept → default to the universal JSON fallback. Clone so the
+	// negotiation override is not visible to callers/middleware that still hold r.
 	clone := r.Clone(r.Context())
-	clone.Header.Set("Accept", accept)
+	clone.Header.Set("Accept", ContentTypeJSON)
 	ReplyError(w, clone, err)
 }
 


### PR DESCRIPTION
### Purpose

A content endpoint (`HandleBytes`) serves raw bytes whose success media type — `application/octet-stream`, `image/png`, `text/html` — cannot carry a structured `Reply`. When a handler failed *before* writing any bytes, DUH tried to encode the error in the client's `Accept` media type, could not, and returned `455 Unsupported Media Type` — masking the real status the handler returned (a `404` became a `455`).

This change makes a pre-body error carry the handler's real status with a body the client can always decode. It also removes a reassignable package `var` that was both a data race and a global-customization footgun, replacing it with a per-handler pattern.

**What this enables for callers:**

Return an error before the first byte and the client now gets your real status as a decodable `Reply` — no code change required:

```go
duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
    return duh.NewServiceError(duh.CodeNotFound, "path not found", nil, nil)
})
// client Accept: image/png  ->  HTTP 404, Content-Type: application/json, {"code":"404",...}
```

Negotiation rules a caller can rely on for a pre-body error:

| Client sends | Error encoded as |
|---|---|
| `Accept: octet-stream` / `image/png` / `text/html` / empty | JSON (universal fallback) |
| `Accept: application/json` | JSON |
| `Accept: application/protobuf` | Protobuf (explicit opt-in only) |
| any request `Content-Type` | ignored — never drives error encoding |

To emit a **non-standard** error (e.g. an HTML page), write your own response and return `nil`:

```go
duh.HandleBytes(w, r, func(r *http.Request, bw duh.BytesWriter) error {
    w.Header().Set("Content-Type", "text/html; charset=utf-8")
    w.WriteHeader(http.StatusNotFound)
    _, _ = w.Write([]byte("<html><body>not found</body></html>"))
    return nil // nil == "I answered; don't send a Reply"
})
```

> **Note:** this reverses the original ticket's acceptance criterion "request `Content-Type: protobuf` → protobuf error" — that criterion was the bug. Error encoding is negotiated by `Accept` only.

### Implementation

- **`service.go` — `ReplyContentError` is now a plain `func`, not a reassignable `var`.** This removes the data race on the mutable package var and the global-leak where reassigning it changed error rendering for every content endpoint in the process. Per-endpoint customization now lives in the handler (write-your-own-response + `return nil`).
- **`service.go` — Accept-only negotiation.** Dropped the request `Content-Type` heuristic. When the client's `Accept` is not `Reply`-capable, the error clones the request and forces `Accept: application/json` (the DUH client always links the JSON codec). An explicit `Accept: application/protobuf` still negotiates protobuf. The clone keeps the override invisible to caller/middleware that still hold `r`.
- **`service.go` — `HandleBytes` doc comment** extended with the render-your-own-error contract (return `nil` when you answer yourself; return a non-nil error only for the standard `Reply`; never both).
- **`example_test.go` — `ExampleHandleBytes_renderOwnError`** documents the custom-error pattern as a runnable, output-verified example that surfaces in godoc under `HandleBytes`.
- **`bytes_writer_test.go`** — removed the override-var test; replaced the "prefers protobuf" test with `ExplicitProtobufAccept` (explicit protobuf Accept → protobuf) and `ContentTypeIgnored` (protobuf `Content-Type` + octet/empty Accept → JSON); added `HandleBytesHandlerRendersOwnError`. Kept the JSON-fallback, reply-capable-Accept, and no-mutate tests.
- **`docs/spec.md`** — reconciled the `455` and JSON-fallback rules: `455` is reserved for a structured-endpoint *success* the client genuinely cannot accept, never a content-endpoint error; `Content-Type` MUST NOT influence error encoding.
- **`docs/features/ENG-138-content-endpoint-errors/handlebytes-errors-explainer.html`** — an outside-in explainer of the behavior from the handler author's perspective.

Fixes ENG-138