### PR TITLE
pagination: replace functional options with IteratorConfig struct

### DIFF
--- a/design-spec-alignment.md
+++ b/design-spec-alignment.md
@@ -157,9 +157,15 @@ type Page struct {
 
 type Iterator[T any] struct { /* ... */ }
 
+// IteratorConfig configures an Iterator. A nil *IteratorConfig uses defaults.
+type IteratorConfig struct {
+    // RetryPolicy retries failed fetch calls. Nil disables retries.
+    RetryPolicy *retry.Policy
+}
+
 func NewIterator[T any](
     fetch func(ctx context.Context, cursor string) ([]T, Page, error),
-    opts ...IteratorOption,
+    conf *IteratorConfig,
 ) *Iterator[T]
 
 func (it *Iterator[T]) Next(ctx context.Context, page *[]T) bool
@@ -171,8 +177,8 @@ func (it *Iterator[T]) Err() error
   their own page size and parameters.
 - `Next` populates the provided slice with the next page of results and returns
   true, or returns false when iteration is complete or an error occurs.
-- Retry is handled internally using the retry policy provided via options. The
-  context passed to `Next` governs both the RPC call and retry cancellation.
+- Retry is handled internally using the retry policy provided via `IteratorConfig`.
+  The context passed to `Next` governs both the RPC call and retry cancellation.
 - The `Page` metadata (cursors, has_next_page) is internal bookkeeping and is not
   exposed to the caller.
 
@@ -188,7 +194,7 @@ iter := duh.NewIterator(func(ctx context.Context, cursor string) ([]User, duh.Pa
         EndCursor:   resp.Pagination.EndCursor,
         HasNextPage: resp.Pagination.HasNextPage,
     }, err
-}, duh.WithRetryPolicy(retry.OnRetryable))
+}, &duh.IteratorConfig{RetryPolicy: &duh.OnRetryable})
 
 var page []User
 for iter.Next(ctx, &page) {

--- a/pagination.go
+++ b/pagination.go
@@ -26,26 +26,17 @@ type Page struct {
 	HasNextPage bool
 }
 
-// iteratorConfig holds configuration for the iterator.
-type iteratorConfig struct {
-	retryPolicy *retry.Policy
-}
-
-// IteratorOption configures an Iterator.
-type IteratorOption func(*iteratorConfig)
-
-// WithRetryPolicy configures the iterator to retry failed fetch calls using the given policy.
-func WithRetryPolicy(p retry.Policy) IteratorOption {
-	return func(c *iteratorConfig) {
-		c.retryPolicy = &p
-	}
+// IteratorConfig configures an Iterator. A nil *IteratorConfig uses defaults.
+type IteratorConfig struct {
+	// RetryPolicy retries failed fetch calls. Nil disables retries.
+	RetryPolicy *retry.Policy
 }
 
 // Iterator provides cursor-based pagination over any paginated endpoint.
 // It is NOT safe for concurrent use.
 type Iterator[T any] struct {
 	fetch  func(ctx context.Context, cursor string) ([]T, Page, error)
-	config iteratorConfig
+	config IteratorConfig
 	cursor string
 	err    error
 	done   bool
@@ -56,11 +47,11 @@ type Iterator[T any] struct {
 // the caller constructs the request with their own page size and parameters.
 func NewIterator[T any](
 	fetch func(ctx context.Context, cursor string) ([]T, Page, error),
-	opts ...IteratorOption,
+	conf *IteratorConfig,
 ) *Iterator[T] {
-	var cfg iteratorConfig
-	for _, opt := range opts {
-		opt(&cfg)
+	var cfg IteratorConfig
+	if conf != nil {
+		cfg = *conf
 	}
 	return &Iterator[T]{
 		fetch:  fetch,
@@ -79,8 +70,8 @@ func (it *Iterator[T]) Next(ctx context.Context, page *[]T) bool {
 	var pg Page
 	var err error
 
-	if it.config.retryPolicy != nil {
-		err = retry.On(ctx, *it.config.retryPolicy, func(ctx context.Context, _ int) error {
+	if it.config.RetryPolicy != nil {
+		err = retry.On(ctx, *it.config.RetryPolicy, func(ctx context.Context, _ int) error {
 			var fetchErr error
 			items, pg, fetchErr = it.fetch(ctx, it.cursor)
 			return fetchErr

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -43,7 +43,7 @@ func TestIterator(t *testing.T) {
 				t.Fatalf("unexpected cursor: %s", cursor)
 				return nil, duh.Page{}, nil
 			}
-		})
+		}, nil)
 
 		var all []string
 		var page []string
@@ -61,7 +61,7 @@ func TestIterator(t *testing.T) {
 		// HasNextPage == false on first page, iterator stops
 		iter := duh.NewIterator(func(ctx context.Context, cursor string) ([]int, duh.Page, error) {
 			return []int{1, 2, 3}, duh.Page{EndCursor: "", HasNextPage: false}, nil
-		})
+		}, nil)
 
 		var page []int
 		require.True(t, iter.Next(context.Background(), &page))
@@ -76,7 +76,7 @@ func TestIterator(t *testing.T) {
 		// Fetch returns empty items with HasNextPage == false
 		iter := duh.NewIterator(func(ctx context.Context, cursor string) ([]string, duh.Page, error) {
 			return nil, duh.Page{HasNextPage: false}, nil
-		})
+		}, nil)
 
 		var page []string
 		// Next returns true because the fetch succeeded (even with empty items)
@@ -93,7 +93,7 @@ func TestIterator(t *testing.T) {
 		fetchErr := errors.New("connection refused")
 		iter := duh.NewIterator(func(ctx context.Context, cursor string) ([]string, duh.Page, error) {
 			return nil, duh.Page{}, fetchErr
-		})
+		}, nil)
 
 		var page []string
 		assert.False(t, iter.Next(context.Background(), &page))
@@ -109,10 +109,10 @@ func TestIterator(t *testing.T) {
 				return nil, duh.Page{}, errors.New("transient error")
 			}
 			return []string{"ok"}, duh.Page{HasNextPage: false}, nil
-		}, duh.WithRetryPolicy(retry.Policy{
+		}, &duh.IteratorConfig{RetryPolicy: &retry.Policy{
 			Interval: retry.Sleep(time.Millisecond),
 			Attempts: 5,
-		}))
+		}})
 
 		var page []string
 		require.True(t, iter.Next(context.Background(), &page))
@@ -125,10 +125,10 @@ func TestIterator(t *testing.T) {
 		// Fetch always fails, retry attempts exhausted
 		iter := duh.NewIterator(func(ctx context.Context, cursor string) ([]string, duh.Page, error) {
 			return nil, duh.Page{}, errors.New("persistent error")
-		}, duh.WithRetryPolicy(retry.Policy{
+		}, &duh.IteratorConfig{RetryPolicy: &retry.Policy{
 			Interval: retry.Sleep(time.Millisecond),
 			Attempts: 3,
-		}))
+		}})
 
 		var page []string
 		assert.False(t, iter.Next(context.Background(), &page))
@@ -147,7 +147,7 @@ func TestIterator(t *testing.T) {
 				return nil, duh.Page{}, ctx.Err()
 			}
 			return []string{"item"}, duh.Page{EndCursor: "next", HasNextPage: true}, nil
-		})
+		}, nil)
 
 		var page []string
 		// First call succeeds
@@ -175,7 +175,7 @@ func TestIterator(t *testing.T) {
 				t.Fatal("too many calls")
 				return nil, duh.Page{}, nil
 			}
-		})
+		}, nil)
 
 		var page []int
 		for iter.Next(context.Background(), &page) {
@@ -192,7 +192,7 @@ func TestIterator(t *testing.T) {
 		iter := duh.NewIterator(func(ctx context.Context, cursor string) ([]string, duh.Page, error) {
 			fetchCalls++
 			return nil, duh.Page{}, errors.New("error")
-		})
+		}, nil)
 
 		var page []string
 		assert.False(t, iter.Next(context.Background(), &page))


### PR DESCRIPTION
### Purpose

`pagination.go` was the only place in duh.go that configured an entry point with functional
(`With…`) options. Every other configurable entry point takes a `*Config` struct pointer
(`HandleStream`, `SetupTLS`, `WaitForConnect`). That inconsistency hurt discoverability — IDE
autocomplete surfaces struct fields far better than a scattered set of `With…` constructors — and
made the library feel like two codebases.

This change makes pagination match the rest of the module: `NewIterator` now takes an exported
`*IteratorConfig` (nil = defaults) instead of variadic options.

Before:

```go
iter := duh.NewIterator(fetch, duh.WithRetryPolicy(retry.OnRetryable))
```

After:

```go
iter := duh.NewIterator(fetch, &duh.IteratorConfig{RetryPolicy: &duh.OnRetryable})
// or, no retries:
iter := duh.NewIterator(fetch, nil)
```

Retry behavior is unchanged: a non-nil `RetryPolicy` retries failed fetches exactly as before;
nil (or a nil config) disables retries.

This is a **breaking API change** to `NewIterator` — all in-repo callers and tests are updated in
this PR. It surfaced while designing the `HandleBytes` error-customization API (ENG-138), where we
deliberately chose a `*Config` struct to match `HandleStream`, highlighting pagination as the
outlier.

### Implementation

- **`pagination.go`** — Removed the unexported `iteratorConfig`, the `IteratorOption` function
  type, and the `WithRetryPolicy` constructor. Added an exported `IteratorConfig` struct with a
  single `RetryPolicy *retry.Policy` field. `NewIterator` now takes `conf *IteratorConfig` and
  copies it (nil → zero-value defaults); the `Next` retry path reads `config.RetryPolicy`. No
  change to iteration semantics.
- **`pagination_test.go`** — Updated all 9 `NewIterator` call sites to the new signature (`, nil`
  for the default cases; `&duh.IteratorConfig{RetryPolicy: …}` for the two retry tests). Surface
  tests only — iteration behavior unchanged.
- **`design-spec-alignment.md`** — Updated the iterator API sketch and usage example to the struct
  form (and corrected the example's `retry.OnRetryable` → `duh.OnRetryable`).

Fixes ENG-140
